### PR TITLE
Add some more Scientology and JW domains

### DIFF
--- a/AntiPreacherList.txt
+++ b/AntiPreacherList.txt
@@ -1,5 +1,5 @@
 ! Title: 💸 Anti-'Insane religious preachers' List
-! Version: 12September2019v3-Alpha
+! Version: 12September2019v1-Alpha
 ! Expires: 7 days
 ! Description: This is a dual-compatibility list for domains-list tools and uBlock Origin, which intends to target and prevent access to groups and individuals that preach things that are either very strange, very hateful, or that promote economical scams.
 ! Special shoutout to the writers at https://friendlyatheist.patheos.com/, whose thorough documentation of United States Christian preachers I have borrowed from to make this list far bigger than it'd otherwise be, and whose site owner (Hemant Mehta) I support on Patreon at the time of writing.
@@ -14,6 +14,7 @@
 # ——— Christian insane preachers ———
 afr.net
 allscripturebaptist.com
+americanevangelicals.com
 americansfortruth.org
 answersingenesis.org
 askdrbrown.org
@@ -24,13 +25,22 @@ charismanews.com
 christianidentityministries.com
 christinthewild.com
 coachdavelive.com
+discovermms.com
 ericburtonministries.org
+evangelicalsforbiblicalimmigration.com
 faithbaptistchalmette.com
 faithfulwordbaptist.org
 focusonthefamily.com
+g2crforum.net
+g2sacraments.org
 generals.org
 generations.org
+genesis2chile.cl
 genesis2church.ch
+genesis2church.is
+genesis2church.nl
+genesis2church297.com
+genesis2churchafrica.org
 globalvisionbc.com
 god.tv
 godsvoice.us
@@ -40,9 +50,9 @@ inspiration.org
 inspirationcampmeeting.com
 jesus-is-savior.com
 jimbakkershow.com
+jw-api.org
 jw.org
 jw2019.org
-jw-api.org
 katkerr.com
 kcm.org
 kingidentity.com
@@ -53,7 +63,13 @@ marycolbert.us
 mattysparadigm.org
 mikemurdockbooks.com
 miraclerevivalchannel.com
+mmsaustralia.com.au
+mmsforum.io
+mmsnews.is
+mmstestimonials.co
+mmswiki.is
 mountainbaptist.org
+officialg2churchmembership.org
 olivetreeviews.org
 oneplace.com
 ovm.org
@@ -89,43 +105,7 @@ vcyamerica.org
 visjonnorge.com
 vssvisjonnorge.wordpress.com
 wisdomonline.com
-evangelicalsforbiblicalimmigration.com
-americanevangelicals.com
-genesis2church297.com
-genesis2churchafrica.org
-g2sacraments.org
-genesis2chile.cl
-genesis2church.nl
-g2crforum.net
-discovermms.com
-mmsaustralia.com.au
-genesis2church.is
-mmsforum.io
-mmsnews.is
-mmstestimonials.co
-officialg2churchmembership.org
-mmswiki.is
 *.bible
-
-# ——— Non-denominational pro-bleach-consumption insane preachers ———
-cdautism.org
-faim.org
-jimhumble.biz
-ketokerri.com
-kvlab.com
-miraclemineral.org
-mms-healthyliving.com
-mmstestimonials.co
-realkerririvera.com
-
-# ——— New Age insane preachers ———
-synergisticuniverse.com
-bodysoulspiritexpo.com
-
-# ——— Holistic insane preachers ———
-naturalnews.com
-
-# ——— Insane preachers for other religions ———
 
 # ——— Scientology ———
 scientology.org
@@ -147,91 +127,113 @@ scientology.gr
 scientology.it
 scientology.pt
 scientology.tv
-standardadmin.org
-ondemandhosting.info
-d2b7dvhy31wn1l.cloudfront.net
 9165619.com
-lronhubbard.org
-d1en0cs4s0ez90.cloudfront.net
-scientologynews.org
-thewaytohappiness.org
-criminon.org
 able.org
 appliedscholastics.org
-greenfieldsschool.com
-effectiveeducation.net
-gelc.org.uk
-delphian.org
-zielschule.ch
-helplearn.org
-childrenshousenursery.com
 appliedscholasticsonline.com
-narconon.org
-d1svpt9wxixxsr.cloudfront.net
-drugfreeworld.org
-humanrights.com
-youthforhumanrights.org
-cchr.org
-citizenscommissiononhumanrights.ca
 cchr.ie
+cchr.org
 cchr.org.za
-freedommag.org
-freedommag.at
-freedommag.be
-freedommag.ca
-freedommag.org.za
+childrenshousenursery.com
+citizenscommissiononhumanrights.ca
+criminon.org
+d1en0cs4s0ez90.cloudfront.net
+d1svpt9wxixxsr.cloudfront.net
+d2b7dvhy31wn1l.cloudfront.net
+deinemenschenrechte.de
+delphian.org
+dianetics.ch
+drugfreeworld.org
+effectiveeducation.net
 freedom.de
 freedom.dk
 freedom.org.mx
+freedom.org.nz
+freedommag.at
+freedommag.be
+freedommag.ca
+freedommag.es
 freedommag.fr
 freedommag.ie
-freedommag.org.il
 freedommag.it
 freedommag.jp
 freedommag.nl
-freedom.org.nz
 freedommag.no
-freedommag.ru
-freedommag.es
-freedommag.se
+freedommag.org
+freedommag.org.il
 freedommag.org.uk
-whatisscientology.org
-progmedia.edgesuite.net
-keytolife.com
-standleague.org
-volunteerministers.org
-volunteerministers.org.au
-ministrovoluntario.mx
-volunteerministers.ca
-volunteerministers.org.uk
-volunteerministers.ie
-volunteerministers.org.nz
-frivilligpraest.dk
-vmisrael.co.il
-volunteerministers.jp
-volunteerministers.ru
-volunteerminister.tw
-xn--nknteslelkszek-ckbi3s.hu
+freedommag.org.za
+freedommag.ru
+freedommag.se
 frivilligpastorer.se
+frivilligpraest.dk
+gelc.org.uk
+greenfieldsschool.com
+helplearn.org
+humanrights.com
+jugend-fuer-menschenrechte.de
+keytolife.com
+lronhubbard.org
+ministrovoluntario.mx
+narconon.org
+ondemandhosting.info
+progmedia.edgesuite.net
+scientology-basel.org
 scientologycourses.org
-scientologyreligion.org
-scientologyreligion.org.tw
-scientologyreligion.org.mx
-scientologyreligion.org.il
-scientologyreligion.nl
-scientologyreligion.se
-scientologyreligion.dk
+scientologynews.org
+scientologynews.org
 scientologyreligion.de
-scientologyreligion.it
+scientologyreligion.dk
 scientologyreligion.es
 scientologyreligion.gr
-scientologyvallas.hu
+scientologyreligion.it
+scientologyreligion.nl
+scientologyreligion.org
+scientologyreligion.org.il
+scientologyreligion.org.mx
+scientologyreligion.org.tw
 scientologyreligion.ru
-scientologynews.org
-scientology-basel.org
-dianetics.ch
-deinemenschenrechte.de
-jugend-fuer-menschenrechte.de
+scientologyreligion.se
+scientologyvallas.hu
+standardadmin.org
+standleague.org
+thewaytohappiness.org
+vmisrael.co.il
+volunteerminister.tw
+volunteerministers.ca
+volunteerministers.ie
+volunteerministers.jp
+volunteerministers.org
+volunteerministers.org.au
+volunteerministers.org.nz
+volunteerministers.org.uk
+volunteerministers.ru
+whatisscientology.org
+xn--nknteslelkszek-ckbi3s.hu
+youthforhumanrights.org
+zielschule.ch
+
+# ——— Non-denominational pro-bleach-consumption insane preachers ———
+cdautism.org
+faim.org
+jimhumble.biz
+ketokerri.com
+kvlab.com
+miraclemineral.org
+mms-healthyliving.com
+mmstestimonials.co
+realkerririvera.com
+
+# ——— New Age insane preachers ———
+synergisticuniverse.com
+bodysoulspiritexpo.com
+
+# ——— Holistic insane preachers ———
+naturalnews.com
+
+# ——— Insane preachers for other religions ———
+# None at the moment. Help is wanted and appreciated, especially for religions that currently have no entries in this list.
+# In particular, it turned out to be far more difficult than expected to find non-state-related Muslim insane preachers than I expected, even ones from Middle East and west-of-India Asia.
 
 # ——— Entries for uBlock Origin and AdGuard ———
 !#include uBO%20list%20extensions/AntiPreacherList-AdblockerExtension.txt


### PR DESCRIPTION
I also moved Scientology to a seperate section as there is now a huge number of domains for them and being able to identify them would probably be helpful. There is also a huge number of domains I'm still missing (especially language variations) but blocking their CDNs and their own hosting provider almost completely breaks most of their directly related sites anyways.

I have decided to also block all schools teaching with applied scholastics, they are run by scientologists, usually reachable via three clicks from the Scientology website and often teach scientologist theories at school.