### PR TITLE
Hide bottom-right notifications on Wikia/Fandom

### DIFF
--- a/WikiaPureBrowsingExperience.txt
+++ b/WikiaPureBrowsingExperience.txt
@@ -22,6 +22,9 @@ wikia.org,fandom.com##.mcf-mosaic
 wikia.org,fandom.com###mixed-content-footer
 wikia.org,fandom.com##.SearchAdsTopWrapper
 
+! Removes sticky notifications from the bottom right
+wikia.org,fandom.com###WikiaNotifications
+
 ! Aims to remove videos that have been baked into the pages by Wikia
 fandom.com,wikia.org##.featured-video__wrapper
 fandom.com,wikia.org#?#.banner-notifications-placeholder:-abp-contains(The video)

--- a/WikiaPureBrowsingExperience.txt
+++ b/WikiaPureBrowsingExperience.txt
@@ -1,8 +1,9 @@
 [Adblock Plus 3.4]
 ! Title: 🎓 Wikia: Pure Browsing Experience
-! Version: 28November2019v1-Beta
+! Version: 29December2019v1-Beta
 ! Expires: 5 days
 ! Description: Do you like to browse casually through different Wikia wikis, but are tired of FANDOM promotions, promotions for movies that you don't care about, and narrow article bodies? Then this list will save your day.
+! Note: To make Wikia pages wider, check out https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Website%20Stretcher.txt. The Wikia rules that were previously in this list, were removed by request and for being arguably superfluous.
 ! For more information, details, helpful tools, and other lists that I've made, visit https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#english
 
 ! An attempt to remove the privacy notice overlay
@@ -36,13 +37,6 @@ fandom.com,wikia.org#?#.banner-notifications-placeholder:-abp-contains(The video
 ! Extraordinarily bad Wikias that you don't want to use
 ||lostmediaarchive.fandom.com$document,domain=~ Warning displayed due to: Brain-damaged knockoff of Lost Media Wiki.
 ||theyayapocalypse.fandom.com$document,domain=~ Warning displayed due to: Incomprehensible nonsense presumably written by drunk teenagers.
-
-! Widens the article bodies (uBlock Origin and Nano Adblocker only)
-! This category is based on 'Clean Wikia', made by Phoenixsong (https://userstyles.org/users/161415)
-wikia.org,fandom.com#?##WikiaPage:style(width: 100% !important; max-width: none !important; margin: 0px !important; padding: 0px  !important)
-wikia.org,fandom.com#?##PageHeader:style(padding: 16px 10px 12px)
-wikia.org,fandom.com#?##WikiaMainContent:style(width: 100% !important; margin: 0px !important)
-wikia.org,fandom.com#?##WikiaMainContentContainer:style(margin: 0px !important)
 
 ! Removes the fandom.wikia.com link from the logos
 wikia.org,fandom.com#?##wds-company-logo-fandom-white:style(pointer-events: none !important; cursor: default !important;)


### PR DESCRIPTION
I recently saw a notification box matching this rule, though I know it’s not the first time I saw one. That recent box said something like “Season 4 is releasing next April.” Info like that could theoretically be helpful to a fan of the subject of whatever wiki I am on, but I don’t think it’s worth bothering every reader with a sticky notification over.

That particular notification box was seen on https://bokunoheroacademia.fandom.com/, but I only got it to show twice. Now, even opening it in a Private Browsing window with uBlock Origin disabled doesn’t show the notification. So you may find this rule hard to test.