### PR TITLE
Wikia/Fandom: hide sponsored links in Popular Pages

### DIFF
--- a/WikiaPureBrowsingExperience.txt
+++ b/WikiaPureBrowsingExperience.txt
@@ -2,7 +2,7 @@
 ! Title: 🎓 Wikia: Pure Browsing Experience
 ! Version: 29December2019v1-Beta
 ! Expires: 5 days
-! Description: Do you like to browse casually through different Wikia wikis, but are tired of FANDOM promotions, promotions for movies that you don't care about, and narrow article bodies? Then this list will save your day.
+! Description: Do you like to browse casually through different Wikia wikis, but are tired of FANDOM promotions, and promotions for movies that you don't care about? Then this list will save your day.
 ! Note: To make Wikia pages wider, check out https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Website%20Stretcher.txt. The Wikia rules that were previously in this list, were removed by request and for being arguably superfluous.
 ! For more information, details, helpful tools, and other lists that I've made, visit https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#english
 

--- a/WikiaPureBrowsingExperience.txt
+++ b/WikiaPureBrowsingExperience.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.4]
 ! Title: 🎓 Wikia: Pure Browsing Experience
-! Version: 29December2019v1-Beta
+! Version: 04January2020v1-Beta
 ! Expires: 5 days
 ! Description: Do you like to browse casually through different Wikia wikis, but are tired of FANDOM promotions, and promotions for movies that you don't care about? Then this list will save your day.
 ! Note: To make Wikia pages wider, check out https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Dandelion%20Sprout's%20Website%20Stretcher.txt. The Wikia rules that were previously in this list, were removed by request and for being arguably superfluous.

--- a/WikiaPureBrowsingExperience.txt
+++ b/WikiaPureBrowsingExperience.txt
@@ -26,6 +26,9 @@ wikia.org,fandom.com##.SearchAdsTopWrapper
 ! Removes sticky notifications from the bottom right
 wikia.org,fandom.com###WikiaNotifications
 
+! Remove links in the Popular Pages sidebar that are to sponsored pages on other wikis
+wikia.org,fandom.com##.rail-sponsored-content
+
 ! Aims to remove videos that have been baked into the pages by Wikia
 fandom.com,wikia.org##.featured-video__wrapper
 fandom.com,wikia.org#?#.banner-notifications-placeholder:-abp-contains(The video)


### PR DESCRIPTION
| Before |  After |
|--------|--------|
| ![Wikia Popular Pages with ad](https://user-images.githubusercontent.com/79168/71748417-78effd80-2e40-11ea-8f6d-ca2b747fb2ce.png) | ![Wikia Popular Pages without ad](https://user-images.githubusercontent.com/79168/71748435-8907dd00-2e40-11ea-8360-e54f24791846.png) |

I also updated the description of the filter list to match the earlier change for #55.