### PR TITLE
Website Stretcher – Wikia: flow sidebars into two columns

### DIFF
--- a/Dandelion Sprout's Website Stretcher.txt
+++ b/Dandelion Sprout's Website Stretcher.txt
@@ -1,5 +1,5 @@
 ! Title: 🖥️ Dandelion Sprout's Website Stretcher
-! Version: 26December2019v1-Beta
+! Version: 04January2020v1-Beta
 ! Expires: 3 days
 ! Licence: https://github.com/DandelionSprout/adfilt/blob/master/LICENSE.md
 ! Description: Have you ever felt bothered by how many websites still think that everyone are using narrow monitors? Well, here's how to stretch them out like a piece of gum!

--- a/Dandelion Sprout's Website Stretcher.txt
+++ b/Dandelion Sprout's Website Stretcher.txt
@@ -235,6 +235,11 @@ wikia.org,fandom.com###WikiaPage:style(width: 100% !important; max-width: none !
 wikia.org,fandom.com###PageHeader:style(padding: 16px 10px 12px)
 wikia.org,fandom.com###WikiaMainContent:style(width: 100% !important; margin: 0px !important)
 wikia.org,fandom.com###WikiaMainContentContainer:style(margin: 0px !important)
+! Flow the sidebars (which were moved to the bottom of the page) into 2 columns to save vertical space.
+! These rules mostly emulate the website’s rules at a small breakpoint when this happens naturally.
+wikia.org,fandom.com##.WikiaRail:style(display: block !important; column-count: 2 !important; width: auto !important;)
+wikia.org,fandom.com##.rail-module:style(break-inside: avoid !important;)
+wikia.org,fandom.com##.rail-sticky-module:style(position: static !important;)
 
 ! ————————————————————————————————————————————————————————————————————
 


### PR DESCRIPTION
Before:

![sidebars in one tall column before these styles](https://user-images.githubusercontent.com/79168/71748725-6cb87000-2e41-11ea-9125-8162e532981a.png)


After:

![sidebars in two columns with these styles](https://user-images.githubusercontent.com/79168/71748634-2bc05b80-2e41-11ea-8ed9-c4acb4f59543.png)