### PR TITLE
Update NorwegianList.txt for bt.no

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -636,6 +636,10 @@ vafo.dk##.adform-flexblock
 ! dinside.no, seher.no
 ##.adunit-wrapper
 ! bt.no
+www.bt.no##div.vertical-x1-ad
+www.bt.no##.proaktiv-ad
+||www.finn.no/distribution-carousel?$object
+||www.finn.no$subdocument
 ##.premium-spot
 ! latterkula.no/se-streamerne-som-vinner-store-gevinster-mens-de-streamer-live/
 ##.annonser

--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1,4 +1,4 @@
-! Version: 02February2020v2
+! Version: 02February2020v3
 ! Title: 🏔️ Dandelion Sprouts nordiske filtre for ryddigere nettsider
 ! Translated title: Dandelion Sprout's Nordic filters for tidier websites
 ! Expires: 12 hours
@@ -246,13 +246,17 @@ digi.no##.native
 ||adframe.no^
 ||adstream.no^
 ||advertising.no^
+bt.no##section[class$=-ad]
+||finn.no$subdocument,domain=bt.no
 ! — — — — —
+! 🇳🇴: Generelle oppføringer med kilder
+! 🇬🇧: Generic entries that have sources
 !#if !ext_ublock
 @@||vgtv.no$generichide
 ||adnxs.com^$domain=vgtv.no
 !#endif
 ! framtia.no, sovesten.no, arendalstidende.no, bil24.no, 730.no, frettatiminn.is, opp.no
-! The ':not' exception is needed for opp.no
+! (Exception: opp.no)
 ##.gofollow:not([href*="radioe6"])
 ! https://www.totensblad.no/2019/nyheter/forsynte-seg-gradig-av-medaljene-i-nm/
 ##a[href*="/?utm_source=strossle"]
@@ -276,6 +280,8 @@ digi.no##.native
 ~prisguiden.no##.prisguidePost
 ! tv2.no
 ##.spklw-post-attr[data-type=ad]
+! bt.no
+||finn.no/distribution-carousel?$object,3p
 
 ! 🇳🇴: ——— Tomme restebokser som EasyList har etterlatt ———
 ! 🇩🇰: ——— Tomme restebokser, som EasyList har efterladt ———
@@ -597,7 +603,10 @@ railgun.dk##.widget_widget_ads
 krs247.no##.prl-span-12 + h5
 gamer.no##.aaa-980x150
 studievalg.no###top-announce
+bt.no##.vertical-x1-ad > .column--big
 ! — — — — —
+! 🇳🇴: Generelle oppføringer med kilder
+! 🇬🇧: Generic entries that have sources
 !#if !env_mobile
 seher.no##.content-marketing-ribbon:style(margin-top: 20px !important)
 !#endif
@@ -636,10 +645,6 @@ vafo.dk##.adform-flexblock
 ! dinside.no, seher.no
 ##.adunit-wrapper
 ! bt.no
-www.bt.no##div.vertical-x1-ad
-www.bt.no##.proaktiv-ad
-||www.finn.no/distribution-carousel?$object
-||www.finn.no$subdocument
 ##.premium-spot
 ! latterkula.no/se-streamerne-som-vinner-store-gevinster-mens-de-streamer-live/
 ##.annonser
@@ -867,7 +872,7 @@ viafree.*##.pause-ad-container
 ||viafree.*/collect$important,xhr
 
 ! 🇳🇴: Korrigerer veldig grell feilinformasjon på Elkjøp og Elgiganten Danmark, hvor EU-energimerkingen til en del produkter fortsatt brukte før-2016-fargene, som førte til tilfeller hvor f.eks. en A-merking var mørkegrønn mens en A+-merking var gul med et hint av grønt.
-! 🇩🇰: Rætter op i rigtigt grim fejlinformation på Elgiganten og Elkjøp, der EU-energimærkingen til mange produkter stadigt benytter før-2016-fargene, noget der førede til tilfelder der fx. et A-merke var mørkegrøn mens et A+-merke var gult med et hint af grøn.
+! 🇩🇰: Rætter op i rigtigt grim fejlinformation på Elgiganten og Elkjøp, der EU-energimærkingen for mange produkter stadigt benytter før-2016-farvene, noget der førede til tilfelder der fx. et A-merke var mørkegrøn mens et A+-merke var gult med et hint af grøn.
 ! 🇬🇧: Fixing very severe misadvertising on Elkjøp and Elgiganten Denmark, in which the EU energy labels for a lot of products were still showing the colours of the pre-2016 labels, leading to cases where e.g. an A label was dark green while an A+ label was yellow with a hint of green.
 ! Amazingly, this does not seem to be a problem on elko.is or elding.fo, so kudos to them.
 elkjop.no,elgiganten.dk###A-value:style(fill: #fff12c !important)


### PR DESCRIPTION
- Blokkerer diverse reklamer fra Finn
- Fjerner en del tomme bokser

Er det mulig å generalisere den `www.bt.no##.proaktiv-ad` til å ta alt `www.bt.no##.*-ad` så antar jeg det ville vært mer effektivt. Jeg har ikke sett noen andre, men de er vel rundtom / kommer med tiden

🙏 