### PR TITLE
Stop the YouTube endscreen on youtube-nocookie.com

### DIFF
--- a/StopAutoplayOnYouTube.txt
+++ b/StopAutoplayOnYouTube.txt
@@ -10,7 +10,7 @@
 
 ! ——— YouTube ———
 ! Note: Video suggestions after the video is finished, will not be shown.
-/endscreen.js$script,domain=youtube.com
+/endscreen.js$script,domain=youtube.com|youtube-nocookie.com
 youtube.com###head.ytd-compact-autoplay-renderer
 youtube.com##.checkbox-on-off
 youtube.com##.watch-sidebar-head


### PR DESCRIPTION
Hello,
I just added the `youtube-nocookie.com` domain to your `/endscreen.js$script,domain=youtube.com` filter.
The endscreen came up when I viewed an embedded YouTube video.

Thanks,
Doug