### PR TITLE
Block sponsored divs on BA.no

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -394,6 +394,7 @@ avvir.no##.avvir-block-top.avvir-block-container
 ba.no###cm2-1
 ba.no##.maelstrom-topbanner
 ba.no##.adp-inscreen
+ba.no##.sponsored
 bilnorge.no###artikkel300x250right
 bilnorge.no###nettboard_art1
 bilnorge.no#?#tr:-abp-has(td:-abp-contains(Annonse:))


### PR DESCRIPTION
By blocking the  `.sponsored` divs on ba.no more ads are removed.