### PR TITLE
Add Chinese site QR code self promo

### DIFF
--- a/AdRemovalListForUnusualAds.txt
+++ b/AdRemovalListForUnusualAds.txt
@@ -41,3 +41,6 @@ mewe.com##.emoji-picker-promotion
 
 ! ——— Huge third-party newsletter promotions ———
 bulbapedia.bulbagarden.net###upper-article
+
+! ——— QR code self promo on Chinese sites ———
+xinhuanet.com##.s-ewm


### PR DESCRIPTION
WeChat channel subscription (aka subscription account, account for
public) is easily found by searching on WeChat itself. If not,
one may always find it on some page like "Contact us". Some similar
but significantly less popular Chinese services include Alipay channel
and channels in 3rd party apps. We don't want that floating QR code or
any button that lures/imposes users to click, after which a QR code
appears, to obstruct user experience.

The following elements will be included:
		QR code that doesn't appear on contact page AND:
				* appears (semi-)globally on footer, header, banner or sidebar
				* appears as a floating element
				* any buttons that introduce a QR code upon mouseover

It will not include:
		Scan QR code to login (will be added to
		BrowseWebsitesWithoutLoggingIn)
		QR code for apps (will be added to Staying On The Phone Browser)