### PR TITLE
Unblock TV 2 assets, and block just ads script

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -339,7 +339,7 @@ storfjordnytt.no##.wpls-logo-clearfix
 ||widgets.sprinklecontent.com^$app=no.startsiden.bookmarks
 !#endif
 !+ NOT_OPTIMIZED
-||tv2a.dk^
+||scripts.tv2a.dk/*tv2ads.js^
 !+ NOT_OPTIMIZED
 ||adframe.no^
 !+ NOT_OPTIMIZED

--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1,4 +1,4 @@
-! Version: 16July2020v1
+! Version: 16July2020v2
 ! Title: 🏔️ Dandelion Sprouts nordiske filtre for ryddigere nettsider
 ! Translated title: Dandelion Sprout's Nordic filters for tidier websites
 ! Expires: 12 hours
@@ -328,6 +328,8 @@ storfjordnytt.no##.wpls-logo-clearfix
 @@||storfjordnytt.no/wp-content/uploads/*/lesarbilete*.jpg^
 @@||storfjordnytt.no/wp-content/uploads/*/leseabilete*.jpg^
 @@||storfjordnytt.no/wp-content/uploads/*/tafjord*.jpg^
+||scripts.tv2a.dk/*tv2ads.js^
+||scripts.tv2a.dk/prebid*
 !#if !ext_ublock
 ||freewheel-mtgx-tv.akamaized.net^$app=no.viafree.android|dk.viafree.android
 ||ssl-mtgstream.tns-cs.net^$app=no.viafree.android|dk.viafree.android
@@ -338,9 +340,6 @@ storfjordnytt.no##.wpls-logo-clearfix
 ||discoverynordics.hb.omtrdc.net^$app=com.discovery.dplay
 ||widgets.sprinklecontent.com^$app=no.startsiden.bookmarks
 !#endif
-!+ NOT_OPTIMIZED
-||scripts.tv2a.dk/*tv2ads.js^
-||scripts.tv2a.dk/prebid*^
 !+ NOT_OPTIMIZED
 ||adframe.no^
 !+ NOT_OPTIMIZED
@@ -368,11 +367,6 @@ storfjordnytt.no##.wpls-logo-clearfix
 ##.ad-paied-cont-front
 ! https://www.langrenn.com/cppage.6250314-1743.html
 ##.spklw-post-attr[data-recommendation-type=ad]
-! https://sport.tv2.dk/formel-1/2019-10-15-jeg-viste-alle-hvad-man-ikke-skal-goere-siger-magnussen
-@@||tv2a.dk/js/lazysizes
-! https://nyheder.tv2.dk/samfund/2019-11-04-vold-fanget-paa-video-gerningsmand-fik-lov-at-gaa-fri-i-tre-aar
-@@||tv2a.dk/js/Video
-@@||tv2a.dk/js/tv2player
 ! bobilverden.no
 /annonse-$image
 ~digi.no##img[alt^=Annonse]

--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -340,6 +340,7 @@ storfjordnytt.no##.wpls-logo-clearfix
 !#endif
 !+ NOT_OPTIMIZED
 ||scripts.tv2a.dk/*tv2ads.js^
+||scripts.tv2a.dk/prebid*^
 !+ NOT_OPTIMIZED
 ||adframe.no^
 !+ NOT_OPTIMIZED


### PR DESCRIPTION
tv2a.dk is "TV 2 Assets", and not "TV 2 Ads"
It includes functional scripts (web.tv2a.dk), fonts (fonts.tv2a.dk), and also our GDPR compliance enabler scripts (https://scripts.tv2a.dk/oil.eHJf.js etc.)

Our ads script is  at https://scripts.tv2a.dk/ads/tv2ads.js (And might in the future be at the root of the domain), and another at https://scripts.tv2a.dk/prebid/prebid.js

The current rules causes serious degradation of our site.

At the [time of when this rule was introduced](https://github.com/DandelionSprout/adfilt/issues/49), we didn't use this domain for much - but since then, we've added much more to it.

**Disclaimer:** I'm a developer at TV 2, for tv2.dk