### PR TITLE
Fix mail.google.com

### DIFF
--- a/ExtremelyCondensedList.txt
+++ b/ExtremelyCondensedList.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.4]
 ! Title: 🍚 Extremely Condensed Adblocking List
-! Version: 24July2020v1-Alpha
+! Version: 15August2020v1-Alpha
 ! Expires: 7 days
 ! Description: Originally made as a proof-of-concept to see how few entries that a modern-day adblocker would need to block ads, this list aims for at least 90% of EasyList's coverage with less than 0.2% as many entries.
 ! Beware that this list doesn't have nearly as good coverage against malware sites as what EasyList has. Therefore, caution should currently be taken when visiting porn and piracy sites when only using this list.
@@ -13,7 +13,7 @@
 ##.ad-panel
 ##.ad-slot
 ##.adbox
-##.ads
+~mail.google.com##.ads
 ##.adsbygoogle
 ##.adunit
 ##.adunit-wrapper


### PR DESCRIPTION
Original report: `https://www.wilderssecurity.com/threads/ublock-a-lean-and-fast-blocker.365273/page-192#post-2939831`
I would have ignored this if it was about other sites, but you know, it's Gmail. Assumed `~mail.google.com` is more suitable to the concept of the list, sorry if you prefer `#@#` or your intention is not to include such whitelist. 