### PR TITLE
3rd update for #81

### DIFF
--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.4]
 ! Title: 💊 Dandelion Sprout's Anti-Malware List
-! Version: 08October2020v1-Beta
+! Version: 08October2020v2-Beta
 ! Expires: 5 days
 ! Description: Most anti-malware lists are pretty big and can cover a 5- or 6-digit amount of specific domains. But my list hereby claims to remove more than 25% of all known malware sites with just a 2-digit amount of entries. This is mostly done by blocking top-level domains that have become devastatingly abused by spammers, usually because they allowed for free and uncontrolled domain registrations. There's also additional categories that cover unusual malware and phishing domains that very few other lists seem to cover.
 ! For other security-specific lists I've made, check out https://github.com/DandelionSprout/adfilt/tree/master/Special%20security%20lists
@@ -9,17 +9,17 @@
 ! ——— Bad top-level domains ———
 ! You can expect these domains to have an overwhelming majority of malware domains that have nothing to do with the countries in question. Nevertheless, if you are in a situation where you have to do active business in any of the countries in question, then this list may not be ideal for you.
 ! Tokelau
-||tk^$doc,domain=~coolcmd.tk|~budterence.tk|~google.tk|~transportnews.tk|~unicorncardlist.tk|~c0d3c.tk|~anonytext.tk|~tokelau-info.tk|~fakaofo.tk|~loljp-wiki.tk|~ninetail.tk|~goshujin.tk|~graph.tk|~haopro.tk|~dls2.pokeacer.tk|~nolfrevival.tk|~coppersurfer.tk|~ Warning displayed due to: It's a top-level domain that allows free website registration; which made it abused by scammers.
+||tk^$doc,domain=~coolcmd.tk|~budterence.tk|~google.tk|~transportnews.tk|~unicorncardlist.tk|~c0d3c.tk|~anonytext.tk|~tokelau-info.tk|~fakaofo.tk|~loljp-wiki.tk|~ninetail.tk|~goshujin.tk|~graph.tk|~haopro.tk|~dls2.pokeacer.tk|~nolfrevival.tk|~coppersurfer.tk
 ! Gabon
-||ga^$doc,domain=~google.ga|~filtri-dns.ga|~dgdi.ga|~voitures.ga|~ Warning displayed due to: It's a top-level domain that allows free website registration; which made it abused by scammers.
+||ga^$doc,domain=~google.ga|~filtri-dns.ga|~dgdi.ga|~voitures.ga
 ! Mali
-||ml^$doc,domain=~google.ml|~mobili.ml|~melody.ml|~dcod.ml|~ Warning displayed due to: It's a top-level domain that allows free website registration; which made it abused by scammers.
+||ml^$doc,domain=~google.ml|~mobili.ml|~melody.ml|~dcod.ml
 ! Equatorial Guinea
-||gq^$doc,domain=~deimos.gq|~inege.gq|~tvgelive.gq|~comprarcarros.gq|~ Warning displayed due to: It's a top-level domain that allows free website registration; which made it abused by scammers.
+||gq^$doc,domain=~deimos.gq|~inege.gq|~tvgelive.gq|~comprarcarros.gq
 ! Central African Republic
-||cf^$doc,domain=~google.cf|~rths.cf|~voitures.cf|~assembleenationale-rca.cf|~cps-rca.cf|~acap.cf|~ Warning displayed due to: It's a top-level domain that allows free website registration; which made it abused by scammers.
+||cf^$doc,domain=~google.cf|~rths.cf|~voitures.cf|~assembleenationale-rca.cf|~cps-rca.cf|~acap.cf
 ! Palau
-||pw^$doc,domain=~libgen.pw|~petridish.pw|~palaugov.pw|~ Warning displayed due to: It's a top-level domain that allows free website registration; which made it abused by scammers.
+||pw^$doc,domain=~libgen.pw|~petridish.pw|~palaugov.pw
 ! International topical domains that have consistently horrendous scores on watchlists of bad TLDs, and whose use for legit purposes is practically non-existent.
 ||loan^$doc
 ||agency^$doc
@@ -188,8 +188,8 @@ howtoremove.guide#?#.entry-content > div:-abp-contains(Special Offer)
 2-spyware.com,novirus.uk,faravirus.ro,uirusu.jp,virusi.hr,wubingdu.cn,avirus.hu,ioys.gr,odstranitvirus.cz,tanpavirus.web.id,utanvirus.se,virukset.fi,losvirus.es,virusler.info.tr,semvirus.pt,lesvirus.fr,senzavirus.it,dieviren.de,viruset.no,usunwirusa.pl,zondervirus.nl,bedynet.ru,virusai.lt,virusi.bg,viirused.ee,udenvirus.dk#?#a:-abp-contains(SpyHunter)
 
 ! Common scam domain patterns
-/(apps?|best|competition|game|mobile|play|prize|reward|sweeps)[0-9]{2,8}\.[a-z-]{5,22}[0-9]{1,8}\.(icu|life|live)/$1p,doc,domain=icu|life|live|~ Warning shown due to: Fraudulently claiming you have won a new phone
-/^https://[a-z]{6,}[0-9]{1,2}\.live/[0-9]{10}/$doc,domain=live|~ Warning shown due to: Fraudulently claiming you have won a new phone
+/(apps?|best|competition|game|mobile|play|prize|reward|sweeps)[0-9]{2,8}\.[a-z-]{5,22}[0-9]{1,8}\.(icu|life|live)/$1p,doc,domain=icu|life|live
+/^https://[a-z]{6,}[0-9]{1,2}\.live/[0-9]{10}/$doc,domain=live
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58737
 /^https?://[-0-9a-z]{14,}\.fun/[a-z]{10,11}\.php.*/$doc,domain=fun
 /^https://www\.namejp0[1-9]\.xyz/$doc,popup,domain=xyz

--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -189,7 +189,7 @@ howtoremove.guide#?#.entry-content > div:-abp-contains(Special Offer)
 
 ! Common scam domain patterns
 /(apps?|best|competition|game|mobile|play|prize|reward|sweeps)[0-9]{2,8}\.[a-z-]{5,22}[0-9]{1,8}\.(icu|life|live)/$1p,doc,domain=icu|life|live|~ Warning shown due to: Fraudulently claiming you have won a new phone
-/^https://[a-z]{6,17}[0-9]{1,2}\.live/$doc,domain=live|~ Warning shown due to: Fraudulently claiming you have won a new phone
+/^https://[a-z]{6,}[0-9]{1,2}\.live/[0-9]{10}/$doc,domain=live|~ Warning shown due to: Fraudulently claiming you have won a new phone
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58737
 /^https?://[-0-9a-z]{14,}\.fun/[a-z]{10,11}\.php.*/$doc,domain=fun
 /^https://www\.namejp0[1-9]\.xyz/$doc,popup,domain=xyz


### PR DESCRIPTION
Given https://github.com/AdguardTeam/AdguardFilters/issues/65221, I think it's better to remove the upper limit for # of characters in the regex. However, whether it is the lucky visitor scam or not these scam domains are always followed by 10-char length numbers at least currently so I hope adding this condition is enough to prevent FP.