### PR TITLE
Fix the new parcel tracker for Posten

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1349,6 +1349,8 @@ avvir.no###block-block-1 > p:nth-of-type(4)
 ! 🇩🇰: ——— Fiksing af knækte websider ———
 ! 🇮🇸: ——— Óbrot ———
 ! 🇬🇧: ——— Unbreakage ———
+! Postens new parcel tracker, fixes the form for giving them delivery information (doorbell name/number)
+@@||glow.posten.no/api/tracking/*$xhr,1p
 ! Makes articles that would be counted as ads anywhere else on SeHer, show up on that page.
 @@||seher.no/reise$ghide
 ! folkebladet.no; Makes job position lists show up correctly

--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1,4 +1,4 @@
-! Version: 22November2020v4
+! Version: 23November2020v1
 ! Title: 🏔️ Dandelion Sprouts nordiske filtre for ryddigere nettsider
 ! Translated title: Dandelion Sprout's Nordic filters for tidier websites
 ! Expires: 1 day
@@ -1349,7 +1349,7 @@ avvir.no###block-block-1 > p:nth-of-type(4)
 ! 🇩🇰: ——— Fiksing af knækte websider ———
 ! 🇮🇸: ——— Óbrot ———
 ! 🇬🇧: ——— Unbreakage ———
-! Postens new parcel tracker, fixes the form for giving them delivery information (doorbell name/number)
+! Posten's new parcel tracker, fixes the form for giving them delivery information (doorbell name/number)
 @@||glow.posten.no/api/tracking/*$xhr,1p
 ! Makes articles that would be counted as ads anywhere else on SeHer, show up on that page.
 @@||seher.no/reise$ghide


### PR DESCRIPTION
Fixes this form
![QoSrDHmrm3WSvBHnhgOYVhT5KvpxKZ](https://user-images.githubusercontent.com/1681525/99979036-f731f700-2da6-11eb-8df9-126ac7e84d88.png)

It sends a *POST* request to `https://glow.posten.no/api/tracking/64AA3E64-90BE-4609-BAB5-4C42847AAB5F/ADD_OR_UPDATE_DELIVERY_LOCK_CODE`
With this payload
```
{
    "type": "ADD_OR_UPDATE_DELIVERY_LOCK_CODE",
    "payload": {
        "id": "64AA3E64-90BE-4609-BAB5-4C42847AAB5F",
        "lockCode": "Navn navnesen / 808"
    }
}
```