### PR TITLE
Wikia/Fandom: Remove custom wiki background and header background images

### DIFF
--- a/WikiaPureBrowsingExperience.txt
+++ b/WikiaPureBrowsingExperience.txt
@@ -57,3 +57,13 @@ wikia.org,fandom.com##.post-search-results__slant
 
 ! Removes "Related wiki" from search results
 fandom.com##.unified-search__layout__right-rail
+
+! Removes custom wiki background and header background images 
+||nocookie.net/*/images/5/50/Wiki-background/*$important
+||wikia.com/*/images/5/50/Wiki-background/*$important
+||nocookie.net/*/images/4/45/*$important
+||nocookie.net/*/images/0/0e/Community-header-background/*$important
+
+! Removes other wiki advertising images
+||vignette.wikia.nocookie.net/*/images/0/0e/*$important
+||vignette.wikia.nocookie.net/*/images/c/cd/*$important


### PR DESCRIPTION
These filters worked to remove (probably most) background path pattern I've seen on fandom.com
I use $important because it conflicts with the easylist filter
Not sure if its efficient though, I hope you could review it :)
please tell if there is any breakage happening because of this too