### PR TITLE
Removing cid and vfadid

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -586,6 +586,9 @@ $removeparam=vifNav
 $removeparam=afcode
 ! https://bcy.net/item/detail/6871525119949282312?_source_page=hashtag
 $removeparam=_source_page
+! https://www.voxi.co.uk/plans#plans?cid=aff-UK_20_7_P_X_A_J_D_VOXI_BAU_Drive_digidip%20UK%20and%20USA%20-%20Incentivized_Native_PAYG-FSIM_NA_NA_BAU_NA_NA_NA&vfadid=10951_249371
+$removeparam=cid
+$removeparam=vfadid
 
 ! ——— Amazon ———
 ! https://www.amazon.com/Razer-Core-Thunderbolt-External-Enclosure/dp/B07CQG2K5K/?tag=makeusw-20&linkCode=ogi&th=1&psc=1 (15/11/2020)

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 26June2021v4-Beta
+! Version: 30June2021v1-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, ad.fly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! If you like this list and wish for more people to use it, give some thumbs up to the https://github.com/AdguardTeam/FiltersRegistry/issues/401 and https://github.com/AdguardTeam/FiltersRegistry/issues/400 threads.
@@ -47,7 +47,7 @@ $removeparam=dclid
 ! https://www.proshop.dk/HyperX-Predator-RGB-ram?cid=64e93f7a-cee2-44d9-911a-37f3eafd7b5f (23/01/2021)
 $removeparam=afid
 ! Can NOT be made generic (e.g. due to sparebank1.no, RARbg.to, Disney+)
-$removeparam=cid,domain=apple.com|www.microsoft.com|telenor.no|proshop.no|proshop.dk|rightmove.co.uk|giphy.com|nbcnews.com
+$removeparam=cid,domain=apple.com|www.microsoft.com|telenor.no|proshop.no|proshop.dk|rightmove.co.uk|giphy.com|nbcnews.com|voxi.co.uk
 ! https://www.digitalimpuls.no/WebPages/Produkt/ProduktInfo.aspx?plid=75672&WebSiteMapNodeID=1000001 (15/11/2020)
 $removeparam=WebSiteMapNodeID
 ! https://cdon.no/elektronikk/apple-thunderbolt-to-gigabit-ethernet-adapter-nettverksadapter-thunderbolt-gigabit-ethernet-p54223599?country=NO&g=20364854 (15/11/2020)
@@ -587,7 +587,6 @@ $removeparam=afcode
 ! https://bcy.net/item/detail/6871525119949282312?_source_page=hashtag
 $removeparam=_source_page
 ! https://www.voxi.co.uk/plans#plans?cid=aff-UK_20_7_P_X_A_J_D_VOXI_BAU_Drive_digidip%20UK%20and%20USA%20-%20Incentivized_Native_PAYG-FSIM_NA_NA_BAU_NA_NA_NA&vfadid=10951_249371
-$removeparam=cid
 $removeparam=vfadid
 
 ! ——— Amazon ———


### PR DESCRIPTION
Example URL https://www.voxi.co.uk/plans#plans?cid=aff-UK_20_7_P_X_A_J_D_VOXI_BAU_Drive_digidip%20UK%20and%20USA%20-%20Incentivized_Native_PAYG-FSIM_NA_NA_BAU_NA_NA_NA&vfadid=10951_249371 which was clicked on from https://www.hotukdeals.com/deals/15gb-ps10-was-8gb-20gb-endless-video-ps15-was-15gb-all-plans-with-endless-social-media-texts-mins-picture-messages-at-voxi-3754450