### PR TITLE
Don't apply rules for Google Search on Google Docs

### DIFF
--- a/Alternate versions Anti-Malware List/AntiMalwareAdGuard.txt
+++ b/Alternate versions Anti-Malware List/AntiMalwareAdGuard.txt
@@ -48,19 +48,19 @@ google.*##.g:has(a[href^="https://books.google."])
 
 ! ——— For Google Mobile ———
 ! I strongly recommend the use of https://addons.mozilla.org/firefox/addon/google-search-fixer/ for use on Firefox for Android, thus the entries are written for the Chrome version of Google Mobile.
-google.*#?#*:has(> * > a[oncontextmenu][href*=".tk/"]:not([href*=coolcmd], [href*=budterence], [href*="google.tk"], [href*=transportnews], [href*=c0d3c], [href*=anonytext], [href*=tokelau-info], [href*=fakaofo], [href*=loljp-wiki], [href*=ninetail], [href*=goshujin], [href*="graph.tk"], [href*=nolfrevival], [href*="steamroller.tk"], [href*="restricted-functions.tk"]))
-google.*#?#*:has(> * > a[oncontextmenu][href*=".ga/"]:not([href*="google.ga"], [href*=filtri-dns], [href*=anpigabon], [href*="dgdi.ga"], [href*=voitures], [href*="economie-gabon.ga"]))
-google.*#?#*:has(> * > a[oncontextmenu][href*=".ml/"]:not([href*="google.ml"], [href*="mobili.ml"], [href*="melody.ml"], [href*="dcod.ml"], [href*="info-matin.ml"], [href*="amap.ml"], [href*="mastodon.ml"], [href*="worproject.ml"]))
-google.*#?#*:has(> * > a[oncontextmenu][href*=".gq/"]:not([href*="deimos.gq"], [href*="inege.gq"], [href*=tvgelive], [href*=comprarcarros]))
-google.*#?#*:has(> * > a[oncontextmenu][href*=".cf/"]:not([href*="google.cf"], [href*="rths.cf"], [href*=voitures], [href*=assembleenationale-rca], [href*=cps-rca], [href*="acap.cf"], [href*="miraculousladybug.cf"]))
-google.*#?#*:has(> * > a[oncontextmenu][href*=".pw/"]:not([href*="libgen.pw"], [href*="petridish.pw"], [href*="palaugov.pw"], [href*="dpc.pw"], [href*="zikrap.pw"]))
-google.*#?#*:has(> * > a[oncontextmenu][href*=".loan/"])
-google.*#?#*:has(> * > a[oncontextmenu][href*=".agency/"])
-google.*#?#*:has(> * > a[oncontextmenu][href*=".gdn/"])
-google.*#?#*:has(> * > a[oncontextmenu][href*=".bid/"])
-google.*#?#*:has(> * > a[oncontextmenu][href*=".top/"])
-google.*#?#*:has(> * > a[oncontextmenu][href*=".php?xxx="])
-google.*#?#*:has(> * > a[oncontextmenu][href^="https://books.google."])
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".tk/"]:not([href*=coolcmd], [href*=budterence], [href*="google.tk"], [href*=transportnews], [href*=c0d3c], [href*=anonytext], [href*=tokelau-info], [href*=fakaofo], [href*=loljp-wiki], [href*=ninetail], [href*=goshujin], [href*="graph.tk"], [href*=nolfrevival], [href*="steamroller.tk"], [href*="restricted-functions.tk"]))
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".ga/"]:not([href*="google.ga"], [href*=filtri-dns], [href*=anpigabon], [href*="dgdi.ga"], [href*=voitures], [href*="economie-gabon.ga"]))
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".ml/"]:not([href*="google.ml"], [href*="mobili.ml"], [href*="melody.ml"], [href*="dcod.ml"], [href*="info-matin.ml"], [href*="amap.ml"], [href*="mastodon.ml"], [href*="worproject.ml"]))
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".gq/"]:not([href*="deimos.gq"], [href*="inege.gq"], [href*=tvgelive], [href*=comprarcarros]))
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".cf/"]:not([href*="google.cf"], [href*="rths.cf"], [href*=voitures], [href*=assembleenationale-rca], [href*=cps-rca], [href*="acap.cf"], [href*="miraculousladybug.cf"]))
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".pw/"]:not([href*="libgen.pw"], [href*="petridish.pw"], [href*="palaugov.pw"], [href*="dpc.pw"], [href*="zikrap.pw"]))
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".loan/"])
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".agency/"])
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".gdn/"])
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".bid/"])
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".top/"])
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href*=".php?xxx="])
+~docs.google.com,google.*#?#*:has(> * > a[oncontextmenu][href^="https://books.google."])
 
 ! ——— Old dead tech-related domains ———
 ! Domains that used to host lists for adblockers or "hosts" tools, but which are now either used by malware pushers, or could potentially be snapped up by them.


### PR DESCRIPTION
These rules may slow down heavy Google Docs since the DOM is too complicated there, and it's modified too often there, we have to-reapply those (rather slow) rules all the time.