### PR TITLE
Update SyntaxMeaningsThatAreActuallyHumanReadable.md

### DIFF
--- a/Wiki/SyntaxMeaningsThatAreActuallyHumanReadable.md
+++ b/Wiki/SyntaxMeaningsThatAreActuallyHumanReadable.md
@@ -17,7 +17,7 @@
 * `[href$="text"]`: Finds page elements whose value *ends* with the text.
 * `[href*="text"]`: Finds page elements whose value contains the text anywhere within it.
 * `[href~="text"]`: Finds page elements whose value contains the word (with spaces around it) anywhere within it.
-* `[href|="text"]`: Same as `[href="text"]`, but can also select text that is then followed by a dash.
+* `[href|="text"]`: Same as `[href="text"]`, but can also select text that is then followed by a hyphen `-`.
 * `:not(.element)`: Finds page elements that doesn't contain a specified element or text string.
 * `:-abp-contains(text)`: Finds page elements that contains such text within it.
 * `:-abp-has(.element)`: Finds page elements that contains such an element within it.


### PR DESCRIPTION
Small update. Hopefully I don't bother too much :) I happened to realize that hyphen and dash have a difference. Hyphen is the shortest one that is being used with `|` selector filter and dash is bit longer and different symbol.

https://www.rd.com/wp-content/uploads/2019/02/dashes.jpg?resize=768,512

I also made the symbol visible so people who didn't know what hyphen means, will see it visually.