### PR TITLE
Remove complex front rule

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1,6 +1,6 @@
 ! Title: 🏔️ Dandelion Sprouts nordiske filtre for ryddigere nettsider
 ! Translated title: Dandelion Sprout's Nordic filters for tidier websites
-! Version: 13September2021v1
+! Version: 14September2021v1
 ! Expires: 1 day
 ! Lisens / Licence: https://github.com/DandelionSprout/adfilt/blob/master/LICENSE.md
 ! Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md

--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -198,7 +198,6 @@ mobilsiden.dk##.content-widget-HTML
 momondo.*##.type-provider.clearfix.flights
 musikknyheter.no##.spklw-widget
 nakenprat.com##+js(aopr, document.dispatchEvent)
-nettavisen.no##.optimus-complex-front
 nettavisen.no##.rel-article
 nettavisen.no##[param-editionid=reklame]
 ni.dk#?#.color-scheme-1:-abp-contains(/Casino/i)


### PR DESCRIPTION
A complex front on Nettavisen, only means that two or more stories are grouped together. It does not indicate that the content is an ad