### PR TITLE
Remove related articles selector

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -199,7 +199,6 @@ momondo.*##.type-provider.clearfix.flights
 musikknyheter.no##.spklw-widget
 nakenprat.com##+js(aopr, document.dispatchEvent)
 nettavisen.no##.optimus-complex-front
-nettavisen.no##.rel-article
 nettavisen.no##[param-editionid=reklame]
 ni.dk#?#.color-scheme-1:-abp-contains(/Casino/i)
 ni.dk#?#.color-scheme-1:-abp-contains(/Casino/i) + div


### PR DESCRIPTION
This rule removes related stories to the main story and does not indicate an ad