### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1065,6 +1065,10 @@ $removeparam=p_tok
 ||bilibili.com^$removeparam=share_tag
 ! https://www.virustotal.com/gui/file/cdecce5824e901bbbd97c0f933c15a14a4f2c1b260da17d8081b6b87cf306c2f/community
 ||ccleaner.com^$removeparam=x-acqsource
+! https://www.wsj.com/?mod=wsjheader_logo
+$removeparam=mod,domain=barrons.com|marketwatch.com|wsj.com
+! https://www.barrons.com/articles/verizon-brady-dividend-stocks-51630700797?siteid=yhoof2
+$removeparam=siteid,domain=barrons.com|marketwatch.com
 
 ! ——— Can never be made generic ———
 ! (e.g. due to sparebank1.no, RARbg.to, Disney+ newsletter unsubscriptions)

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 15September2021v4-Beta
+! Version: 15September2021v5-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, ad.fly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! If you like this list and wish for more people to use it, give some thumbs up to the https://github.com/AdguardTeam/FiltersRegistry/issues/401 and https://github.com/AdguardTeam/FiltersRegistry/issues/400 threads.

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -772,7 +772,7 @@ $removeparam=/^publisher/i,domain=asos.com|blissworld.com|bose.*|burkesoutlet.co
 $removeparam=pubref,domain=asos.com
 $removeparam=pzid,domain=emirates.com
 $removeparam=/^refID/i,domain=allmodern.com|calphalon.com|priceline.com|wayfair.com|yankeecandle.com
-$removeparam=/^siteid/i,domain=agentprovocateur.com|amerimark.com|anntaylor.com|asos.com|awd-it.*|gap.com|barenecessities.com|beautyencounter.com|buckle.com|burpee.com|chacos.com|coursera.org|dxl.com|dyson.com|elfcosmetics.*|famousfootwear.com|finishline.com|freetaxusa.com|gapcanada.ca|hanes.com|hotwire.com|hulu.com|jcrew.com|josbank.com|kobo.com|lanebryant.com|loft.com|magazines.com|maurices.com|merrell.com|newbalance.com|nordstrom.com|officedepot.com|onehanesplace.com|radissonhotelsamericas.com|saksfifthavenue.com|saksoff5th.com|samash.com|samsclub.com|saucony.com|sharperimage.com|thingsremembered.com|thrifty.*|timeformecatalog.com|verabradley.com|vivaterra.com|wine.com|yoox.com
+$removeparam=/^siteid/i,domain=agentprovocateur.com|amerimark.com|anntaylor.com|asos.com|awd-it.*|gap.com|barenecessities.com|beautyencounter.com|buckle.com|burpee.com|chacos.com|coursera.org|dxl.com|dyson.com|elfcosmetics.*|famousfootwear.com|finishline.com|freetaxusa.com|gapcanada.ca|hanes.com|hotwire.com|hulu.com|jcrew.com|josbank.com|kobo.com|lanebryant.com|loft.com|magazines.com|maurices.com|merrell.com|newbalance.com|nordstrom.com|officedepot.com|onehanesplace.com|radissonhotelsamericas.com|saksfifthavenue.com|saksoff5th.com|samash.com|samsclub.com|saucony.com|sharperimage.com|thingsremembered.com|thrifty.*|timeformecatalog.com|verabradley.com|vivaterra.com|wine.com|yoox.com|barrons.com|marketwatch.com
 $removeparam=/^srcCode/i,domain=jcrew.com|magellans.com|teleflora.com|tigerdirect.com
 $removeparam=scd,domain=ashleystewart.com
 $removeparam=CJPIXEL
@@ -1065,10 +1065,6 @@ $removeparam=p_tok
 ||bilibili.com^$removeparam=share_tag
 ! https://www.virustotal.com/gui/file/cdecce5824e901bbbd97c0f933c15a14a4f2c1b260da17d8081b6b87cf306c2f/community
 ||ccleaner.com^$removeparam=x-acqsource
-! https://www.wsj.com/?mod=wsjheader_logo
-$removeparam=mod,domain=barrons.com|marketwatch.com|wsj.com
-! https://www.barrons.com/articles/verizon-brady-dividend-stocks-51630700797?siteid=yhoof2
-$removeparam=siteid,domain=barrons.com|marketwatch.com
 
 ! ——— Can never be made generic ———
 ! (e.g. due to sparebank1.no, RARbg.to, Disney+ newsletter unsubscriptions)


### PR DESCRIPTION
Removes parameter `mod`  from these:

`https://www.marketwatch.com/story/uipath-stock-falls-following-earnings-beat-outlook-hike-11631046109?mod=mw_more_headlines`

`https://www.barrons.com/articles/utility-stocks-yield-51631063820?mod=hp_columnists`

`https://www.wsj.com/?mod=wsjheader_logo`

_____________

Removes parameter `siteid` from these:

`https://www.barrons.com/articles/verizon-brady-dividend-stocks-51630700797?siteid=yhoof2`

`https://www.marketwatch.com/story/dutch-bros-to-offering-211-million-shares-in-ipo-priced-at-18-to-20-each-2021-09-07?siteid=yhoof2`