### PR TITLE
Add malware domains

### DIFF
--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1090,22 +1090,22 @@ zombooru.com##a[href="http://www.hard55.com"]
 ! https://github.com/DandelionSprout/adfilt/issues/267
 ||tekhacks.net^$all
 ||mediafire.com/file/pj9jdm7iznc4d51/tekhacksnet_multi_loader.rar^$doc
-! ---- INSERT PR URL ----
-! https://www.virustotal.com/gui/file/da75c85fe037f9ff9ebbbd0b37dd2ff154f5e70a0dc6870286e0d3df6b8f246f/community
+! https://github.com/DandelionSprout/adfilt/pull/278
+!! https://www.virustotal.com/gui/file/da75c85fe037f9ff9ebbbd0b37dd2ff154f5e70a0dc6870286e0d3df6b8f246f/community
 ||139.28.37.49^$all
-! https://www.virustotal.com/gui/file/ca7072bba9d1b75b02b5d2887fdb7bcb1f86050b669ffd99a7e756e1a60095f2/relations
+!! https://www.virustotal.com/gui/file/ca7072bba9d1b75b02b5d2887fdb7bcb1f86050b669ffd99a7e756e1a60095f2/relations
 ||str-master.pw^$all
-! https://www.virustotal.com/gui/file/717bfbdba55f9c2d820fde170c04fd70c3e0f907b635c13d0f29678ff781f665/community
+!! https://www.virustotal.com/gui/file/717bfbdba55f9c2d820fde170c04fd70c3e0f907b635c13d0f29678ff781f665/community
 ||35.194.188.37^$all
 ||nemscnc.ddns.net^$all
-! https://www.virustotal.com/gui/file/368afeda7af69f329e896dc86e9e4187a59d2007e0e4b47af30a1c117da0d792/community
+!! https://www.virustotal.com/gui/file/368afeda7af69f329e896dc86e9e4187a59d2007e0e4b47af30a1c117da0d792/community
 ||hydro-ca.link^$all
 ||covid19-ca.link^$all
 ||sock.godforgiveuss.live^$all
 ||godforgiveuss.live^$all
-! https://www.virustotal.com/gui/file/c0e40a12643436cb413235e385a6a90deeb6cc13b24458368fd7facb20ac0c81/community
+!! https://www.virustotal.com/gui/file/c0e40a12643436cb413235e385a6a90deeb6cc13b24458368fd7facb20ac0c81/community
 ||91.243.121.19^$all
-! https://www.virustotal.com/gui/file/9f154115fa8045aa05f15f7cd1de9623ebe32e8ea400279ecb5dfa3596952e3b/community
+!! https://www.virustotal.com/gui/file/9f154115fa8045aa05f15f7cd1de9623ebe32e8ea400279ecb5dfa3596952e3b/community
 ||fernandomayol.com^$all
 ||varmisende.com^$all
 ||103.169.90.205^$all

--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.6]
 ! Title: 💊 Dandelion Sprout's Anti-Malware List
-! Version: 18September2021v1-Beta
+! Version: 18September2021v2-Beta
 ! Expires: 5 days
 ! Description: This list goes the extra kilometer to prevent more malware than other mainstream anti-malware lists. It blocks heavily abused top-level domains (and even search engine results for them), blocks domains used in malware redirection trains and in domain parking schemes, blocks sponsored Windows PUP nags on PC guide articles, uses mass blocking of domains belonging to bad IPs, and has many other subcategories that give it a solid advantage over similar lists out there.
 ! For other security-specific lists I've made, check out https://github.com/DandelionSprout/adfilt/tree/master/Special%20security%20lists
@@ -1090,6 +1090,25 @@ zombooru.com##a[href="http://www.hard55.com"]
 ! https://github.com/DandelionSprout/adfilt/issues/267
 ||tekhacks.net^$all
 ||mediafire.com/file/pj9jdm7iznc4d51/tekhacksnet_multi_loader.rar^$doc
+! ---- INSERT PR URL ----
+! https://www.virustotal.com/gui/file/da75c85fe037f9ff9ebbbd0b37dd2ff154f5e70a0dc6870286e0d3df6b8f246f/community
+||139.28.37.49^$all
+! https://www.virustotal.com/gui/file/ca7072bba9d1b75b02b5d2887fdb7bcb1f86050b669ffd99a7e756e1a60095f2/relations
+||str-master.pw^$all
+! https://www.virustotal.com/gui/file/717bfbdba55f9c2d820fde170c04fd70c3e0f907b635c13d0f29678ff781f665/community
+||35.194.188.37^$all
+||nemscnc.ddns.net^$all
+! https://www.virustotal.com/gui/file/368afeda7af69f329e896dc86e9e4187a59d2007e0e4b47af30a1c117da0d792/community
+||hydro-ca.link^$all
+||covid19-ca.link^$all
+||sock.godforgiveuss.live^$all
+||godforgiveuss.live^$all
+! https://www.virustotal.com/gui/file/c0e40a12643436cb413235e385a6a90deeb6cc13b24458368fd7facb20ac0c81/community
+||91.243.121.19^$all
+! https://www.virustotal.com/gui/file/9f154115fa8045aa05f15f7cd1de9623ebe32e8ea400279ecb5dfa3596952e3b/community
+||fernandomayol.com^$all
+||varmisende.com^$all
+||103.169.90.205^$all
 
 ! ——— Standard malware that I stumbled upon on my own ———
 ! http://www.toorgle.net/results.php?q=fetishkitsch&security=666


### PR DESCRIPTION
This PR adds some more malware domains to the antimalware list
(I intended to add https://github.com/DandelionSprout/adfilt/commit/723778f01bcae60d1af9e04b1356cc99a981dfc1 to this PR but I accidentally added it to the main repo