### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 01October2021v1-Beta
+! Version: 01October2021v2-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, ad.fly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1047,7 +1047,7 @@ $removeparam=_nc_vts_prog
 ! https://www.barrons.com/articles/etf-giants-push-back-against-senate-democrat-who-wants-to-take-away-tax-break-51631753035?refsec=hp_INTERESTS_taxes
 $removeparam=refsec,domain=barrons.com
 ! https://www.marketwatch.com/personal-finance/real-estate/rent/united-states/new-york/new-york?reloadLocationOnSearch=false&searchType=suggested&reflink=mc_wsj_search
-$removeparam=reflink,domain=marketwatch.com
+$removeparam=reflink,domain=marketwatch.com|mansionglobal.com
 ! https://edition.cnn.com/?hpt=header_edition-picker
 $removeparam=hpt,domain=cnn.com
 


### PR DESCRIPTION
Removes parameter `reflink` from this:

`https://www.mansionglobal.com/newyork/868134-795-fifth-avenue-10065?reflink=mc_wsj_listing`