### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1132,8 +1132,6 @@ $removeparam=ogbl
 ! https://support.google.com/websearch/answer/9351707?p=featured_snippets&hl=en&visit_id=637669631265857080-3305857145&rd=1
 ||google.$removeparam=visit_id
 
-
-
 !!! ———TikTok———
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-632259
 ||tiktok.com^$removeparam=app
@@ -1722,6 +1720,7 @@ $removeparam=ds_url_v,domain=clickserve.dartsearch.net
 
 ! ——— Rules for heavily covered international sites ——— !
 !! ——— PR-China ———
+!! Special thanks to https://github.com/shenzhiming88 for helping with this section
 !!! ——— AliExpress ———
 ! https://es.aliexpress.com/item/4000672272353.html?pvid=c4cdc770-f05a-4b7b-8a50-d8b81efff6c9&_t=gps-id:pcDetailBottomMoreThisSeller,scm-url:1007.13339.169870.0,pvid:c4cdc770-f05a-4b7b-8a50-d8b81efff6c9,tpp_buckets:668%230%23131923%230_668%23808%234094%23200_668%23888%233325%231_668%232846%238113%23646_668%232717%237558%23188_668%231000022185%231000066059%230_668%233468%2315617%23897
 ||aliexpress.com/item/$removeparam=pvid
@@ -1844,6 +1843,6 @@ $removeparam=width,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno.
 $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno.nu
 !#endif
 
-! ——— Allow List ——— !
+! ——— Allowlist ——— !
 @@mailinglist$removeparam=/^utm_/
 @@||hinta.fi/lib/$removeparam=v


### PR DESCRIPTION
1. Baidu: `https://top.baidu.com/board?platform=pc&sa=pcindex_a_right`
2. Sogou: `https://www.sogou.com/web?user_ip=***.***.***.***&bh=1&interation&interV=kKIOkrELjboMmLkEkL0TkKIMkLELjboImLkEk74TkKIMkrELjbkRmLkEmrELjbgRmLkEkLYTEiTeRFjtjb0EyvdB2u8GwOVFmUHpGz2IOzXejb0Ew+dByOsG0OV/zPsGwOVFmUG8H03sOEX3jb0E0O5Nwu9CyudHj+lHzo==_701355754&htdbg=on&ie=utf8&hintidx=0&query=%E5%BE%B7%E5%AE%89%E6%9D%B0%E6%B4%9B%E5%BE%B7%E5%86%85%E7%BD%97%E9%87%87%E8%AE%BF`
3. I think it would be better to order the sites by dictionary (a-z), so `AliExpress` should come before `Baidu`.