### PR TITLE
Fix for `BaiduNetdisk`

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -2327,7 +2327,6 @@ $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno
 !#endif
 
 ! ——— Allowlist ——— !
-
 @@mailinglist$removeparam=/^utm_/
 
 ! Block users from uploading images.

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 14November2021v3-Beta
+! Version: 14November2021v4-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, ad.fly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -2330,7 +2330,7 @@ $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno
 
 @@mailinglist$removeparam=/^utm_/
 
-! Block users from upload images.
+! Block users from uploading images.
 @@||graph.baidu.com/upload?$removeparam=from
 
 @@||web.archive.org/*_/http$removeparam

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -2327,6 +2327,13 @@ $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno
 !#endif
 
 ! ——— Allowlist ——— !
+
 @@mailinglist$removeparam=/^utm_/
+
+! Block users from upload images.
 @@||graph.baidu.com/upload?$removeparam=from
+
 @@||web.archive.org/*_/http$removeparam
+
+! Block users from saving files in `BaiduNetdisk`.
+@@||pan.baidu.com/share/transfer?$removeparam=from


### PR DESCRIPTION
```
*$removeparam=from,domain=sogou.com|baidu.com|jetbrains.com|bandcamp.com|apkpure.com
```
This rule blocks users from saving files in `BaiduNetdisk`.