### PR TITLE
Remove duplicate filters

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 14November2021v5-Beta
+! Version: 14November2021v6-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, ad.fly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1088,7 +1088,6 @@ $removeparam=ClickThruEmail
 $removeparam=ClickThruCustomerNumber
 
 ! https://scripts.affiliatefuture.com/AFClick.asp?affiliateID=29219&merchantID=2543&programmeID=6678&mediaID=0&tracking=&url=https://example.com/
-^tracker=AFFILIATEFUTURE^$removeparam=tracker
 ^tracker=affiliatefuture^$removeparam=tracker
 $removeparam=affc
 


### PR DESCRIPTION
In uBO, only one of the two rules seems to be loaded (you can copy it to a custom rule and see the number of rules loaded)
![image](https://user-images.githubusercontent.com/66902050/141687219-7c820bee-da03-41d6-a105-5e98eb06b58e.png)
