### PR TITLE
Add Linux malware

### DIFF
--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1342,11 +1342,12 @@ zombooru.com##a[href="http://www.hard55.com"]
 ||big5constructnigeria-staging.bitkit.dk^$all
 ||big5-nigeria.bitkit.dk^$all
 ||bromic-staging.bitkit.dk^$all
-! A PUP
+! A PUP and scam website
 ||mycleanpc.com^$doc
 ! Related domains owned by the same company and used for payment (the first is for 'tech support' scams, the second for their 'ID protection')
 ||ustechsupport.com^$doc
 ||mycleanid.com^$doc
+||iolostore.com^$doc
 ! The main website for the MyCleanPC company
 ||realdefen.se^$doc
 ! Vermilion Strike
@@ -1452,7 +1453,7 @@ zombooru.com##a[href="http://www.hard55.com"]
 ||mediadlvr.com^$all
 ||youvetube.com^$all
 ||youutube.com^$all
-! PR URL here
+! https://github.com/DandelionSprout/adfilt/pull/348
 ! https://www.virustotal.com/gui/file/12013662c71da69de977c04cd7021f13a70cf7bed4ca6c82acbc100464d4b0ef/community
 ||39.83.80.247^$all
 ||68.197.33.124^$all

--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.6]
 ! Title: 💊 Dandelion Sprout's Anti-Malware List
-! Version: 14November2021v1-Beta
+! Version: 15November2021v1-Beta
 ! Expires: 5 days
 ! Description: This list goes the extra kilometer to prevent more malware than other mainstream anti-malware lists. It blocks heavily abused top-level domains (and even search engine results for them), blocks domains used in malware redirection trains and in domain parking schemes, blocks sponsored Windows PUP nags on PC guide articles, uses mass blocking of domains belonging to bad IPs, and has many other subcategories that give it a solid advantage over similar lists out there.
 ! For other security-specific lists I've made, check out https://github.com/DandelionSprout/adfilt/tree/master/Special%20security%20lists
@@ -1452,6 +1452,41 @@ zombooru.com##a[href="http://www.hard55.com"]
 ||mediadlvr.com^$all
 ||youvetube.com^$all
 ||youutube.com^$all
+! PR URL here
+! https://www.virustotal.com/gui/file/12013662c71da69de977c04cd7021f13a70cf7bed4ca6c82acbc100464d4b0ef/community
+||39.83.80.247^$all
+||68.197.33.124^$all
+||219.157.21.37^$all
+||182.123.141.17^$all
+||125.47.243.187^$all
+||182.122.196.203^$all
+||182.117.231.182^$all
+||112.31.211.135^$all
+||125.106.63.93^$all
+||115.59.197.46^$all
+||122.159.29.192^$all
+||171.40.0.127^$all
+||171.80.219.160^$all
+||123.10.65.201^$all
+||168.90.205.46^$all
+||125.47.205.109^$all
+||39.80.147.239^$all
+||45.224.171.130^$all
+||45.5.209.75^$all
+||116.17.210.157^$all
+||27.45.103.240^$all
+||110.167.64.171^$all
+||39.81.117.73^$all
+||183.15.90.156^$all
+||119.113.248.74^$all
+||175.0.95.85^$all
+||61.52.99.109^$all
+||222.142.183.194^$all
+||106.86.172.194^$all
+||103.233.216.77^$all
+||183.188.192.55^$all
+! https://www.virustotal.com/gui/file/3bf1b7e9bdaeaa4a5619cf26b59767637bc44193df2a0470df263b98b1fe47fe/community
+||198.23.255.14^$all
 
 ! ——— Standard malware that I stumbled upon on my own ———
 ! http://www.toorgle.net/results.php?q=fetishkitsch&security=666


### PR DESCRIPTION
This PR adds some ips known for spreading Linux malware and one additional scam domain to _DandelionSprout's anti-malware_ list