### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 14November2021v8-Beta
+! Version: 15November2021v1-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, ad.fly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -2319,6 +2319,17 @@ $removeparam=aff_trace_key
 ||mp.weixin.qq.com^$removeparam=version
 ||mp.weixin.qq.com^$removeparam=exportkey
 ||mp.weixin.qq.com^$removeparam=pass_ticket
+! https://github.com/DandelionSprout/adfilt/pull/349
+$removeparam=clicktime
+$removeparam=nettype
+||mp.weixin.qq.com^$removeparam=abtest_cookie
+||mp.weixin.qq.com^$removeparam=chksm
+||mp.weixin.qq.com^$removeparam=count
+||mp.weixin.qq.com^$removeparam=enterid
+||mp.weixin.qq.com^$removeparam=from_msgid
+||mp.weixin.qq.com^$removeparam=from_itemidx
+||mp.weixin.qq.com^$removeparam=sessionid
+||mp.weixin.qq.com^$removeparam=subscene
 ! https://github.com/DandelionSprout/adfilt/pull/341
 ||qq.com^$removeparam=report_recomm_player
 


### PR DESCRIPTION
Example addresses:
```
https://mp.weixin.qq.com/s?__biz=MzI3NjYzMDM1Mg==&mid=2247496716&idx=1&sn=676885202cf25d6d3097135084b78797&chksm=eb702a33dc07a3255a54505db6feb6b3cc407125d89c7c1c03e78de87b288406ccd69789deb6&subscene=93&sessionid=1636986214&clicktime=1636986409&enterid=1636986409&nettype=ctnet&abtest_cookie=AAACAA%3D%3D&lang=zh_CN
https://mp.weixin.qq.com/mp/appmsgalbum?__biz=MzA4NzQzMzU4Mg==&action=getalbum&album_id=2112911772373303297&from_msgid=2652974105&from_itemidx=2&count=3&nolastread=1#wechat_redirect
```
After a simple test, these rules should be fine.