### PR TITLE
Fix https://github.com/AdguardTeam/AdguardFilters/issues/96952

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 20November2021v3-Beta
+! Version: 21November2021v1-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -2480,3 +2480,6 @@ $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno
 ! https://github.com/DandelionSprout/adfilt/pull/364
 ! Prevent the user from selecting the product type normally - test address: https://b2b.baidu.com/s?q=Test
 @@||b2b.baidu.com/s/a?$removeparam=f
+
+! Cause image upload failure on the forum `bbs.nga.cn` - https://github.com/AdguardTeam/AdguardFilters/issues/96952
+@@||img*.nga$removeparam=cmpid


### PR DESCRIPTION
Issue: https://github.com/AdguardTeam/AdguardFilters/issues/96952

> The rule '$removeparam=cmpid' in URL Tracking filter will cause image upload failure on the forum 'bbs.nga.cn'. The forum has three domains: 'bbs.nga.cn' 'ngabbs.com' 'nga.178.com' and the url for image uploads is 'img8.nga.cn'