### PR TITLE
Fix `mail.qq.com`

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 28November2021v2-Beta
+! Version: 28November2021v3-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1706,6 +1706,8 @@ $removeparam=nettype
 ||mp.weixin.qq.com^$removeparam=subscene
 ! https://github.com/DandelionSprout/adfilt/pull/341
 $removeparam=report_recomm_player
+! https://github.com/DandelionSprout/adfilt/pull/386
+||mail.qq.com/cgi-bin/frame_html?$removeparam=r
 
 !! ——— Miscellaneous ———
 ! No particular examples
@@ -1979,7 +1981,7 @@ $removeparam=tracker,domain=dustdeal.nl|batteryupgrade.*
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1031533
 ||simplelogin.io^$removeparam=slref
-$removeparam=r,domain=ledger.io|mail.qq.com
+||ledger.io^$removeparam=r
 ||roboform.com^$removeparam=rec
 
 ! https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRTQ_thTIPr-4kGYMHEyfPeD9YN_0fwvx4-fQ&usqp=CAU


### PR DESCRIPTION
The original filter causes some functions to **not** work properly, such as "resume". The filter now cleans up only for the parameters in the address bar that the user can see.