### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 29November2021v1-Beta
+! Version: 30November2021v1-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1643,6 +1643,32 @@ $removeparam=aff_click_id
 ^p=1^$removeparam=p,domain=bilibili.com
 ^t=0^$removeparam=t,domain=bilibili.com
 
+!!!! ——— iQIYI ———
+! https://github.com/DandelionSprout/adfilt/pull/390
+! https://www.iqiyi.com/v_126y0fmbvmw.html?vfrm=pcw_home&vfrmblk=D&vfrmrst=712211_focus_A_image1 (30/11/2021)
+||iqiyi.com^$removeparam=vfrm
+||iqiyi.com^$removeparam=vfrmblk
+||iqiyi.com^$removeparam=vfrmrst
+! https://www.iqiyi.com/v_24ootmqzdts.html?r_area=rec_you_like&r_source=230&bkt=MBA_PW_T3_59&e=18c7f339676f3508a87cd758bbe0c711&stype=2 (30/11/2021)
+||iqiyi.com^$removeparam=bkt
+||iqiyi.com^$removeparam=e
+||iqiyi.com^$removeparam=r_area
+||iqiyi.com^$removeparam=r_source
+||iqiyi.com^$removeparam=stype
+! https://www.iqiyi.com/v_2fa0wqg80qw.html?pltfm=11&pos=title&flashvars=videoIsFromQidan%3Ditemviewclk_a#vfrm=5-6-0-1 (30/11/2021)
+||iqiyi.com^$removeparam=flashvars
+||iqiyi.com^$removeparam=pltfm
+||iqiyi.com^$removeparam=pos
+! https://game.iqiyi.com/togame/entry_latest?game_id=10696&pccenter_fr=pcw_banner (30/11/2021)
+||iqiyi.com^$removeparam=pccenter_fr
+! https://list.iqiyi.com/www/2/-149------------11-1-1-iqiyi--.html?s_source=PCW_SC (30/11/2021)
+||iqiyi.com^$removeparam=s_source
+! https://so.iqiyi.com/so/q_%E7%86%8A%E5%87%BA%E6%B2%A1?source=hot&sr=9939350662687346&ssrt=20211130002322412&ssra=1a6f10d51f0055e2a69c43ffb82c3314 (30/11/2021)
+||iqiyi.com^$removeparam=source
+||iqiyi.com^$removeparam=sr
+||iqiyi.com^$removeparam=ssra
+||iqiyi.com^$removeparam=ssrt
+
 !!!! ——— Sogou ———
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1421356
 ||sogou.com^$removeparam=_asf
@@ -1761,7 +1787,7 @@ $removeparam=region,domain=nytimes.com|nytimes3xbfgragh.onion
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1155198
 $removeparam=sm12
-$removeparam=ts,domain=x-kom.pl|al.to|combat.pl|baidu.com|bilibili.com|~api.bilibili.com
+$removeparam=ts,domain=x-kom.pl|al.to|combat.pl|baidu.com|bilibili.com
 $removeparam=token,domain=x-kom.pl|al.to|combat.pl|substack.com
 
 ! http://www.bodenusa.com/?tc_ch=affs&tc_ve=ppj&code=X3W6&tc_so=8439&tc_me=cr&tc_ca=na&tc_au=na&tc_cr=2-420132&tc_campid=na&tc_adgroupid=na&tc_kwid=na&tc_matchid=na
@@ -2482,7 +2508,9 @@ $removeparam=referer,domain=bodykind.com
 ||target.com^$removeparam=marketing_id
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1666311
-$removeparam=s,domain=spreadprivacy.com
+! https://github.com/DandelionSprout/adfilt/pull/390
+! https://v.youku.com/v_show/id_XNTE5MDA0MzA2NA==.html?s=decc0e2f935f461f84b1 (30/11/2021)
+$removeparam=s,domain=spreadprivacy.com|youku.com
 
 ! https://twitter.com/chrissteinplays/status/1461003062936547331?t=CXBXxSiUKI8wPAkoGMH7zg
 $removeparam=t,domain=rakuten.com|steamcdn-a.akamaihd.net|duckduckgo.com|npr.org|twitter.com


### PR DESCRIPTION
Updated `iQIYI` for China, and `Youku`. I have combined them into one big category due to the large number of filters for `iQIYI`.
Also, `~api.bilibili.com` doesn't seem to exclude the domain `api.bilibili.com`, but there should be no damage to that domain to be processed (at least for watching videos).