### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -2627,7 +2627,7 @@ $removeparam=/^quot;/,domain=outnorth.fi
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1726383
 ||catch.com.au^$removeparam=iv_
 
-https://www.coolshop.co.uk/product/don-one-lifestyle-tws120-black-in-ear-true-wireless-stereo-earbuds-with-charging-case/235AS7/?retailAttributionToken=ChM1OTEyOTM2MDQyNjAyNDQwOTgwEA0aI2Nvb2wtLS1yZWNfcmVjb21tZW5kZV8xNjI1MTM0MTA5NDY5Ihxjb29sdWstLS1yZWNvbW1lbmRlZC1mb3IteW91KAA
+! https://www.coolshop.co.uk/product/don-one-lifestyle-tws120-black-in-ear-true-wireless-stereo-earbuds-with-charging-case/235AS7/?retailAttributionToken=ChM1OTEyOTM2MDQyNjAyNDQwOTgwEA0aI2Nvb2wtLS1yZWNfcmVjb21tZW5kZV8xNjI1MTM0MTA5NDY5Ihxjb29sdWstLS1yZWNvbW1lbmRlZC1mb3IteW91KAA
 $removeparam=retailAttributionToken,domain=coolshop.*
 
 ! https://www.bostonglobe.com/business/technology/?p1=BGHeader_MainNav

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 2December2021v1-Beta
+! Version: 3December2021v1-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -2630,6 +2630,9 @@ $removeparam=/^quot;/,domain=outnorth.fi
 https://www.coolshop.co.uk/product/don-one-lifestyle-tws120-black-in-ear-true-wireless-stereo-earbuds-with-charging-case/235AS7/?retailAttributionToken=ChM1OTEyOTM2MDQyNjAyNDQwOTgwEA0aI2Nvb2wtLS1yZWNfcmVjb21tZW5kZV8xNjI1MTM0MTA5NDY5Ihxjb29sdWstLS1yZWNvbW1lbmRlZC1mb3IteW91KAA
 $removeparam=retailAttributionToken,domain=coolshop.*
 
+! https://www.bostonglobe.com/business/technology/?p1=BGHeader_MainNav
+$removeparam=p1,domain=bostonglobe.com
+
 !#if !env_mobile
 ! ——— Mobile ——— !
 ! ——— Entries mostly dedicated to maximising image sizes (thus poorly suited for phones) ———


### PR DESCRIPTION
Cleans `p1` parameter:
`https://www.bostonglobe.com/business/technology/?p1=BGHeader_MainNav`

Added to almost everything you click on that site in the same way as the mod parameter on WSJ.