### PR TITLE
Update regex filters in Anti-Malware List

### DIFF
--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.6]
 ! Title: 💊 Dandelion Sprout's Anti-Malware List
-! Version: 02December2021v1-Beta
+! Version: 04December2021v1-Beta
 ! Expires: 5 days
 ! Description: This list goes the extra kilometer to prevent more malware than other mainstream anti-malware lists. It blocks heavily abused top-level domains (and even search engine results for them), blocks domains used in malware redirection trains and in domain parking schemes, blocks sponsored Windows PUP nags on PC guide articles, uses mass blocking of domains belonging to bad IPs, and has many other subcategories that give it a solid advantage over similar lists out there.
 ! For other security-specific lists I've made, check out https://github.com/DandelionSprout/adfilt/tree/master/Special%20security%20lists
@@ -266,14 +266,9 @@ azdll.net##.dllhelper-banner
 ! Common scam domain patterns
 /^http://(apps?|best|competition|game|mobile|play|prize|reward|sweeps)[0-9]{2,8}\.[a-z-]{5,22}[0-9]{1,8}\.(icu|life|live)/$1p,doc
 /^https://(apps?|best|competition|game|mobile|play|prize|reward|sweeps)[0-9]{2,8}\.[a-z-]{5,22}[0-9]{1,8}\.(icu|life|live)/$1p,doc
-/^https:\/\/[a-z]{7,}\.li[fv]e\/[a-z]{8}\/\?/$doc,popup,domain=life|live
-/^https?:\/\/[-0-9a-z]*prize[-0-9a-z]+\.li[fv]e\/\?u=[0-9a-z]+&o=[0-9a-z]+/$doc,domain=life|live
-/^https?:\/\/[-0-9a-z]*prize[-0-9a-z]+\.li[fv]e\/\?u=[0-9a-z]+&o=[0-9a-z]+/$popup,domain=www.google.*
+/^https:\/\/[-0-9a-z]{12,}\.life\/\?u=[0-9a-z]{7,}&o=[0-9a-z]{7,}&/$doc,domain=life
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58737
-/^https?://(www\.)?[-0-9a-z]{14,}\.fun/[a-z]{10,11}\.php.*/$doc,domain=fun
-! https://github.com/AdguardTeam/AdguardFilters/issues/78614
-/^https?:\/\/\d{6}\.xyz\/lucky\/[-a-z]+\/\?t=/$doc,popup,domain=xyz
-/^https?:\/\/[a-z]{6}\.vip\/lucky\/[-a-z]+\/\?t=/$doc,popup,domain=vip
+/^https?:\/\/(?:www\.)?[-0-9a-z]{14,}\.(?:biz|fun|live)\/[a-zA-Z]{10,}\.php/$doc,domain=biz|fun|live
 
 ! ——— Banner for "MSN New Tab" ———
 msn.com##.irisbanner


### PR DESCRIPTION
Removed obsolete filters and updated others. Unfortunately I can't find an example for `/^https?:\/\/(?:www\.)?[-0-9a-z]{14,}\.(?:biz|fun|live)\/[a-zA-Z]{10,}\.php/$doc,domain=biz|fun|live` but am pretty sure this is still in use.