### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 08December2021v1-Beta
+! Version: 09December2021v1-Beta
 ! Expires: 2 days
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1167,6 +1167,9 @@ $removeparam=rndad
 ! https://www.reddit.com/r/uBlockOrigin/comments/owcag5/previously_blocked_ads_suddenly_showing_on/
 $removeparam=ad_config_id
 
+! https://www.adidas.ca/stan-smith-shoes/GY3533.html?dfw_tracker=76885-GY3533-0001
+$removeparam=dfw_tracker
+
 ! ——— General blocking rules ——— !
 !! Scripts that solely exist to make URLs longer.
 ! https://github.com/DandelionSprout/adfilt/pull/320
@@ -1186,7 +1189,7 @@ $removeparam=ref,domain=amazon.*|deal.no|expo.io|udemy.com|reddit.com|brave.com|
 $removeparam=tid,domain=comixology.*|gap.com|gapcanada.ca|mintmobile.com|zulily.com|clickbank.net
 ! https://addons.thunderbird.net/en-GB/thunderbird/addon/mailbox-alert/?src=cb-dl-users
 ! https://twitter.com/hashtag/mlpg5?src=hashtag_click (23/04/2021)
-$removeparam=src,domain=thunderbird.net|twitter.com|udemy.com|elastix.org|bluejeans.com|melopero.com|kubii.*|reichelt.*|okdo.com|raspipc.es|tiendatec.es|thepihut.com|cytron.io|buyzero.de|welectron.com|digikey.*|adafruit.com|hinta.fi|3cx.com|ashford.com|bose.*|kennethcole.com|kipling-usa.com|newbalance.com|wondershare.*|investors.com|yahoo.com|engadget.com|mozilla.org|viking-direct.co.uk|wuzhuiso.com
+$removeparam=src,domain=thunderbird.net|twitter.com|udemy.com|elastix.org|bluejeans.com|melopero.com|kubii.*|reichelt.*|okdo.com|raspipc.es|tiendatec.es|thepihut.com|cytron.io|buyzero.de|welectron.com|digikey.*|adafruit.com|hinta.fi|3cx.com|ashford.com|bose.*|kennethcole.com|kipling-usa.com|newbalance.com|wondershare.*|investors.com|yahoo.com|engadget.com|mozilla.org|viking-direct.co.uk|wuzhuiso.com|lestijoki.fi|perhonjokilaakso.fi|kalajokilaakso.fi|kalajokiseutu.fi|nivala-lehti.fi|haapavesi-lehti.fi|keskipohjanmaa.fi|selanne-lehti.fi
 ! No particular example
 $removeparam=source,domain=googleusercontent.com|awd-it.*|ashford.com|asos.com|att.com|barenecessities.com|bedbathandbeyond.com|betterprogramming.pub|boscovs.com|boxboat.com|brownells.*|burkesoutlet.com|choicehotels.com|contabo.com|directv.com|drinkhint.com|edx.org|hammacher.com|hanes.com|hottopic.com|housing.com|hp.com|itnext.io|medium.com|nautica.com|onehanesplace.com|petsupplies.com|phonesoap.com|riteaid.com|sonos.com|squarespace.com|thedailybeast.com|tiktok.com|tommybahama.com|torrid.com|tous.com|webhint.io|wilsonsleather.com|wired.com|ylighting.com|jacquielawson.com|fool.com|fiverr.com|blavity.com|eonline.com|tokopedia.com|community.spiceworks.com|despegar.*|hotspotshield.com|gethotspotshield.com|subscribe.gq.com|bankofamerica.com|outnorth.fi
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-525100


### PR DESCRIPTION
Removes `src` from these:

* `https://www.lestijoki.fi/uutinen/628156?src=rss`
* `https://www.perhonjokilaakso.fi/uutinen/628212?src=rss`
* `https://www.kalajokilaakso.fi/uutinen/628247?src=rss`
* `https://www.kalajokiseutu.fi/uutinen/628098?src=rss`
* `https://www.nivala-lehti.fi/uutinen/628248?src=rss`
* `https://www.haapavesi-lehti.fi/uutinen/628126?src=rss`
* `https://www.keskipohjanmaa.fi/uutinen/627841?src=rss`
* `https://www.selanne-lehti.fi/uutinen/627939?src=rss`

_____

I'd also like to try `dfw_tracker` as generic one:

`https://help.datafeedwatch.com/article/i3tguzlilm-analytics-adding-tracker`

Example URLs:

* `https://www.pcnation.com/web/details/6TZ068/digi-ex15-wi-fi-5-ieee-802-11ac-2-sim-ethernet-cellular-modem-wireless-router-asb-ex15-wx06-glb?dfw_tracker=110924-6TZ068`
* `https://www.hifitalo.fi/products/vw-skoda-seat-03-2din-sovite-musta?dfw_tracker=83686-32657826775179`
* `https://www.hellyhansen.com/en_us/shop/activity/sailing?_mof_data=color_group%3A482879&color_group=482879&dfw_tracker=22471-33852_597-STD`
* `https://www.adidas.ca/stan-smith-shoes/GY3533.html?dfw_tracker=76885-GY3533-0001`