### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 30December2021v2-Beta
+! Version: 30December2021v3-Beta
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -2839,6 +2839,10 @@ $removeparam=rx_job,domain=cvshealth.com
 $removeparam=rx_source,domain=cvshealth.com
 $removeparam=rx_ts,domain=cvshealth.com
 $removeparam=rx_p,domain=cvshealth.com
+
+! https://www.paramountplus.com/fi/?cbsclick=QHSXuQw7WxyIWrPQHcWEzT3UUkG2eTztlwcSQ00&vndid=395495
+$removeparam=cbsclick,domain=paramountplus.com|cbs.com
+$removeparam=vndid,domain=paramountplus.com|cbs.com
 
 !#if !env_mobile
 ! ——— Mobile ——— !


### PR DESCRIPTION
Removes `cbsclick` and `vndid`:
* `https://www.paramountplus.com/fi/?cbsclick=QHSXuQw7WxyIWrPQHcWEzT3UUkG2eTztlwcSQ00&vndid=395495`

You can also find similar links to cbs.com if you Google that cbsclick parameter so I added that domain too.