### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 17January2022v2-Beta
+! Version: 19January2022v1-Beta
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -2645,7 +2645,7 @@ $removeparam=referer,domain=bodykind.com
 $removeparam=s,domain=spreadprivacy.com|youku.com|greenhouse.io
 
 ! https://twitter.com/chrissteinplays/status/1461003062936547331?t=CXBXxSiUKI8wPAkoGMH7zg
-$removeparam=t,domain=rakuten.com|steamcdn-a.akamaihd.net|duckduckgo.com|npr.org|elprecio.es|adressa.no
+$removeparam=t,domain=rakuten.com|steamcdn-a.akamaihd.net|duckduckgo.com|npr.org|elprecio.es|adressa.no|tiktok.com
 
 ! https://market.yandex.ru/promo/hasbro_special?clid=602&cpa-perf=1#c
 ||yandex.$removeparam=clid
@@ -3003,6 +3003,12 @@ $removeparam=rcode,domain=kucoin.com
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1979025
 $removeparam=Bibblio_source,domain=macrumors.com
+
+! https://www.goodeeworld.com/products/pluviophile-rain-candle?pr_prod_strat=copurchase&pr_rec_pid=4780770132108&pr_ref_pid=5263231090828&pr_seq=uniform
+$removeparam=/^pr_/,domain=goodeeworld.com|lacemade.com|lifamasks.shop|willi.fi
+
+! https://lifamasks.shop/products/lifa-air-kuvioitu-kirurginen-suu-nenasuojus-type-iir?rpcid=5ccad8f5-b75b-4132-82b7-c6c1ac333dddI363836303a3435373a3336363135
+$removeparam=rpcid,domain=lifamasks.shop
 
 !#if !env_mobile
 ! ——— Mobile ——— !


### PR DESCRIPTION
Remove `t` parameter:
* `https://www.tiktok.com/search/user?q=test&t=1622430306885`

Fix: https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1986042, I didn't notice any issues. The only thing is that, like with all the other parameters on this site, it will only be removed if you reload the page.

______

Remove all `pr_` parameters:
* `https://www.goodeeworld.com/products/pluviophile-rain-candle?pr_prod_strat=copurchase&pr_rec_pid=4780770132108&pr_ref_pid=5263231090828&pr_seq=uniform`

* `https://www.willi.fi/products/zolux-anah-tuplakampaea-470827?pr_prod_strat=collection_fallback&pr_rec_pid=6986912792768&pr_ref_pid=6962804293824&pr_seq=uniform`

* `https://lacemade.com/products/van-gogh-dress?pr_prod_strat=copurchase&pr_rec_pid=7066546864322&pr_ref_pid=7061249622210&pr_seq=uniform`

* `https://lifamasks.shop/products/lifa-air-avaruus-kirurginen-suu-nenasuojus-type-iir-20-kpl-paketti?pr_prod_strat=copurchase&pr_rec_pid=6721470955729&pr_ref_pid=6546187288785&pr_seq=uniform`

Added from product recommendations. Seems similar to `pf_rd_` parameters on Amazon sites.

_____

Remove `rpcid` parameter:
* `https://lifamasks.shop/products/lifa-air-kuvioitu-kirurginen-suu-nenasuojus-type-iir?rpcid=5ccad8f5-b75b-4132-82b7-c6c1ac333dddI363836303a3435373a3336363135`
