### PR TITLE
keyword param is needed to sell on ebay

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1354,6 +1354,7 @@ $removeparam=sid,domain=anrdoezrs.net|dpbolvw.net|gopjn.com|jdoqocy.com|kqzyfj.c
 ! No particular example
 $removeparam=from,domain=apkpure.com|bandcamp.com|jetbrains.com|luisaviaroma.com|sogou.com
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1559915 and https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1559864
+! (eBay can't be added; see https://github.com/DandelionSprout/adfilt/pull/514)
 $removeparam=keyword,domain=bindright.com|lendgo.com
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1707764
 $removeparam=id,domain=go.redirectingat.com|go.skimlinks.com|go.skimresources.com|karkkainen.com

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 18February2022v1
+! Version: 20February2022v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1354,7 +1354,7 @@ $removeparam=sid,domain=anrdoezrs.net|dpbolvw.net|gopjn.com|jdoqocy.com|kqzyfj.c
 ! No particular example
 $removeparam=from,domain=apkpure.com|bandcamp.com|jetbrains.com|luisaviaroma.com|sogou.com
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1559915 and https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1559864
-$removeparam=keyword,domain=bindright.com|ebay.*|lendgo.com
+$removeparam=keyword,domain=bindright.com|lendgo.com
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1707764
 $removeparam=id,domain=go.redirectingat.com|go.skimlinks.com|go.skimresources.com|karkkainen.com
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1726383


### PR DESCRIPTION
`$removeparam=keyword,domain=ebay.*` breaks when selling an item.

To recreate:
1.  Login to ebay and click on Sell at the top of the page
2. Click on `List an item`
3. Type an item in, such as `tripod` and click on the search button
4. Click on `Continue without match` at the bottom of the page
5. Click Used and then `Continue to listing`
6. You now get the `Well, this is embarrassing.` page