### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 01March2022v3
+! Version: 01March2022v4
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -3252,6 +3252,9 @@ $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno
 
 ! Temp fix for Bing - https://github.com/DandelionSprout/adfilt/issues/508
 @@||bing.*/ws/redirect/$removeparam
+
+! Fix the video player 'Invalid signature' - https://www.fox.com/watch/ffae8bb93256fb0d0b3a4b30f00e0ada/ 
+@@||link.theplatform.com/s/fox-dcg/media/$removeparam
 
 !#if adguard
 !#if adguard_ext_firefox


### PR DESCRIPTION
Fixes video player: `https://www.fox.com/watch/ffae8bb93256fb0d0b3a4b30f00e0ada/`

This list currently removes `affiliate` parameter from those requests, but it seems to also break if anything else is removed from it.