### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 25March2022v1
+! Version: 26March2022v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -3263,7 +3263,7 @@ $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno
 
 ! ——— Scriptlets ———
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1352038
-mtvuutiset.fi##+js(set, gsSkyId, noopFunc)
+actionewz.com,animemojo.com,comicbookmovie.com,fearhq.com,gamefragger.com,mtvuutiset.fi,sffgazette.com,theringreport.com,toonado.com##+js(set, GSvars.addressTracking, false)
 
 ! ——— Allowlist ——— !
 ! https://github.com/DandelionSprout/adfilt/commit/6dd010c70438a84cae7cf6b683d0d99dc56794ad


### PR DESCRIPTION
 I think I've found a better solution that will hopefully work for more sites in the future.

Also found more sites, here are some examples:

* `https://sffgazette.com/sci-fi/star_wars/obi-wan-kenobi-new-details-emerge-on-how-the-series-connects-to-a1263#gs.v1aq1h`
* `https://gamefragger.com/multiplatform/first_person_shooter/fortnite/fortnite-no-build-mode-could-be-a-permanent-option-according-to-dataminer-findings-a23342#gs.umrzu2`
* `https://toonado.com/cartoons/meet-bud-collyer-who-played-superman-over-2000-times-on-radio-and-in-animation-a5851#gs.un12kx`

To test that it no longer appends that to the url just try to open them without it: `https://sffgazette.com/sci-fi/star_wars/obi-wan-kenobi-new-details-emerge-on-how-the-series-connects-to-a1263`
