### PR TITLE
Block ads at E24.no

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -95,6 +95,17 @@ doktor.frettabladid.is##.ad-310x400
 dusken.no##.ad-col-article
 dusken.no##.ad-in-column
 e24.no###adPlaceholderFront
+e24.no##[href^="https://e24.no/annonsorinnhold"]
+e24.no###adPlacement_1
+e24.no###adPlacement_2
+e24.no###adPlacement_3
+e24.no###adPlacement_4
+e24.no###adPlacement_5
+e24.no###adPlacement_6
+e24.no##.annonse-label
+e24.no##.logo-container
+e24.no##.content-marketing
+e24.no##.component_content-marketing
 e24.no##.bg-xAdrow
 e24.no##.content-marketing-container
 e24.no##a[href*="/go.click?"]


### PR DESCRIPTION
This blocks two kinds of ads at E24.no. 

Im pretty sure these same filter could be used on all other Scibsted sites (BT, Aftenposten, etc)