### PR TITLE
A Manchester Evening News link that came from Google News

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 27March2022v2
+! Version: 29March2022v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1324,6 +1324,12 @@ $removeparam=x_tr_pto
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-2381922
 $removeparam=oref
+
+! https://www.manchestereveningnews.co.uk/whats-on/manchester-institution-britons-protection-needs-23494921?gaa_at=la&gaa_n=AYc4ysszn1halB6eRkgGnhrQUi-2HXTbnEdyz1BfC7ZD4JCO5et6GNSecUjEb6t9DsA%3D&gaa_ts=624304a6&gaa_sig=CBANf6kZ15XwlMeO9FM2aNZ4W3js3hPmeLw-SqwT8OY5o942zs6TrL_XcPjSVuFfyT3PiHD0FNyci3X1z8vk0w%3D%3D
+$removeparam=gaa_at
+$removeparam=gaa_n
+$removeparam=gaa_ts
+$removeparam=gaa_sig
 
 ! ——— General blocking rules ——— !
 !! Scripts that solely exist to make URLs longer.


### PR DESCRIPTION
Not sure if these gaa_* params are coming from Google News or somewhere else, but they need to be removed.