### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 11June2022v1
+! Version: 13June2022v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -3456,6 +3456,9 @@ $removeparam=height,domain=i-viaplay.com.akamaized.net|media.discordapp.net|tvno
 ! ——— Scriptlets ———
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1352038
 actionewz.com,animemojo.com,comicbookmovie.com,fearhq.com,gamefragger.com,mtvuutiset.fi,sffgazette.com,theringreport.com,toonado.com##+js(set, GSvars.addressTracking, false)
+
+! https://buffalonews.com/news/#tracking-source=main-nav
+buffalonews.com##+js(set, lee_trkLinkSrc, noopFunc)
 
 ! ——— Allowlist ——— !
 ! https://github.com/DandelionSprout/adfilt/commit/6dd010c70438a84cae7cf6b683d0d99dc56794ad


### PR DESCRIPTION
Removes `#tracking-source` from links around the site 
* `https://buffalonews.com/news/#tracking-source=main-nav`
* `https://buffalonews.com/news/local/work-begins-on-gas-station-park-at-center-of-feud-between-amherst-billionaire/article_e3191b48-e8e6-11ec-b777-1b7ef9f69772.html#tracking-source=most-popular-homepage`


