### PR TITLE
Allow gopass.pw

### DIFF
--- a/Alternate versions Anti-Malware List/AntiMalwareAdGuardHome.txt
+++ b/Alternate versions Anti-Malware List/AntiMalwareAdGuardHome.txt
@@ -20,7 +20,7 @@
 ! Central African Republic
 ||cf^$denyallow=google.cf|rths.cf|voitures.cf|assembleenationale-rca.cf|cps-rca.cf|acap.cf|miraculousladybug.cf|scrat.cf
 ! Palau
-||pw^$denyallow=libgen.pw|petridish.pw|palaugov.pw|dpc.pw|zikrap.pw|demonoid.pw|bittor.pw|buttercup.pw|rezka.pw|darkcrystal.pw|xor.pw|fullhdfilmizlesene.pw|b00k.pw
+||pw^$denyallow=libgen.pw|petridish.pw|palaugov.pw|dpc.pw|zikrap.pw|demonoid.pw|bittor.pw|buttercup.pw|rezka.pw|darkcrystal.pw|xor.pw|fullhdfilmizlesene.pw|b00k.pw|gopass.pw
 ! Legitimate use is almost non-existent, but has a tiny userbase in Japan
 ||top^$denyallow=corriente.top|gdtot.top|nicenature.top|reminder.top|magocoro.top|castlevania.top|suiten.top|shucks.top|1stream.top|ambr.top
 ! International topical domains that have consistently horrendous scores on watchlists of bad TLDs, and whose use for legit purposes is practically non-existent.


### PR DESCRIPTION
This is the home of gopass, a password manager for the command line written in Go.
https://github.com/gopasspw/gopass