### PR TITLE
[Clear URLs for uBo] Add Netflix's trackId

### DIFF
--- a/ClearURLs for uBo/compile.py
+++ b/ClearURLs for uBo/compile.py
@@ -67,13 +67,15 @@ KNOWN_BAD_FILTERS = [
     # https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-1796961
     "$removeparam=ved,domain=google.*",
     # https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-2408392
-    '$removeparam=s,domain=amazon.*',
+    "$removeparam=s,domain=amazon.*",
     # https://github.com/DandelionSprout/adfilt/commit/8c3520f272162c70bd48dd27fb7c37a9abf00fa8 - I don't think it is in this list, but added anyway
     "||bing.com^$removeparam=filters",
     # unknown breakage
     "||google.com^$removeparam=dpr",
     "$~xmlhttprequest,removeparam=psc",
     "||walmart.$removeparam=wl13",
+    # Netflix Track ID
+    "$removeparam=trackId,domain=netflix.com",
 ]
 
 ALLOWLIST = """


### PR DESCRIPTION
This removes the `?trackId=NUMBER` from Netflix URLs.
For example: `https://www.netflix.com/watch/80114226?trackId=12345678`

Unsure if `$removeparam=trackId,domain=netflix.com` is better than `||netflix.com$removeparam=trackId`.

Also, following the file's list order, shouldn't the last entry (in this case, `trackId`) have nothing after it instead of having a comma?

I also replaced single quotes to double quotes in an Amazon filter, because following the file's list that seems to be a typo.

Thank you for your attention!