### PR TITLE
Fix domain exception filters for `$removeparam`

### DIFF
--- a/ClearURLs for uBo/compile.py
+++ b/ClearURLs for uBo/compile.py
@@ -34,7 +34,7 @@ HEAD = """\
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
 ! Description: Want to use ClearURLs' tracking protection without installing another extension? This list is a (unofficial) version of the ClearURLs rules, designed for use in uBlock Origin and AdGuard
 ! Last updated: {date}
-! Script last updated: 26/3/2022
+! Script last updated: 12/8/2022
 ! Expires: 1 day
 ! Licence: https://github.com/DandelionSprout/adfilt/blob/master/LICENSE.md
 ! Note: This was based off of https://gist.github.com/rusty-snake/5cd83a87d680ecbd03e79a1a06758207, which is based off of https://github.com/ClearURLs/Rules. The maintainers of Adfilt (DandelionSprout and iam-py-test, and contributors) have made some modifications as to keep it up-to-date with the source and to fix issues
@@ -265,7 +265,7 @@ def main() -> int:
         elif kind == "path":
             filterlist.write("@@{0}$removeparam".format(exception) + "\n")
         elif kind == "domain":
-            filterlist.write("@@$removeparam,domain={0}".format(exception) + "\n")
+            filterlist.write("@@||{0}^$removeparam".format(exception) + "\n")
         else:
             raise ValueError
     filterlist.write(ALLOWLIST)


### PR DESCRIPTION
Currently, the domain exceptions in ClearURLs rules don't seem to work correctly. For example, we have filters like this:
```
$removeparam=callback,domain=bilibili.com
@@$removeparam,domain=api.bilibili.com
```
This should disable `$removeparam` for `api.bilibili.com`. But for some reason, it doesn't work[^env]. `callbcak` parameters are still
 removed, thereby breaking the site.

The following does work as intended, however:
```
@@||api.bilibili.com^$removeparam
```
I don't have much experience with uBO filters, so I don't really understand the difference between those two. Maybe this behavior could be considered an uBO bug? Anyway, please let me know if there's a better way to do this.

[^env]: Chrome `104.0.5112.81`, uBlock Origin `1.43.0`, ClearURLs for uBo `30/06/2022`