### PR TITLE
Update NorwegianList.txt

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1,6 +1,6 @@
 ! Title: 🏔️ Dandelion Sprouts nordiske filtre for ryddigere nettsider
 ! Translated title: Dandelion Sprout's Nordic filters for tidier websites
-! Version: 17August2022v1
+! Version: 19August2022v1
 ! Expires: 1 day
 ! Lisens / Licence: https://github.com/DandelionSprout/adfilt/blob/master/LICENSE.md
 ! Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md
@@ -1555,8 +1555,14 @@ flatpanels.dk###content > .container[style*=padding-bottom][style*=text-align]
 gulesider.no##.ResultListBanner
 nyheder24.dk##div[id^=taboola-right-rail-thumbnails-]
 tvkampen.com,tvsporten.dk##.tvg-manager-tracking-event
+ehandel.*###div-leeadsFullpageAd
 ehandel.*##.article-ad-container
+ehandel.*##.article-content > .code-block
+ehandel.*##.article-sponsored
 ehandel.*##.annons
+ehandel.*##.commercial-row
+ehandel.*##body[data-scrolling] .post-container-sponsored
+ehandel.*#?#.aside-image-with-link:has([href^="https://www.whatsnxt.io/"])
 e24.no##div[data-placement^=native_in_text_]
 vg.no##div[class^=article-wrapper-] > div[class^=" css-"]
 isabellas.dk##div[data-type=ad]


### PR DESCRIPTION
`###div-leeadsFullpageAd` :

<details>
<summary>View image</summary>

![image](https://user-images.githubusercontent.com/84513173/185662921-db95f2f5-22d4-4bf5-8746-067c8ec98cd6.png)

</details>
1px white line at the top.

__________

`##.article-content > .code-block`:

<details>
<summary>View image</summary>

![image](https://user-images.githubusercontent.com/84513173/185663217-92c2b93d-2327-4002-b3d5-776bbbbcf6a9.png)

</details>

__________

`##.article-sponsored`:

<details>
<summary>View image</summary>

![image](https://user-images.githubusercontent.com/84513173/185663346-4b11acfa-578b-4556-9582-7a297b22d98f.png)

</details>

_________

`##.commercial-row`:

<details>
<summary>View image</summary>

![image](https://user-images.githubusercontent.com/84513173/185663818-7faa8dce-1e11-473d-b05d-29331c8b911d.png)

</details>

_________

`##body[data-scrolling] .post-container-sponsored`:

<details>
<summary>View image</summary>

![image](https://user-images.githubusercontent.com/84513173/185664095-53411611-3ecd-4f7d-b6b1-7721ac548e0e.png)

</details>

Hides sponsored articles when scrolling down to it from non-sponsored articles, but not when it's the only article:

<details>
<summary>View image</summary>

![image](https://user-images.githubusercontent.com/84513173/185664442-b614161c-1612-4b5a-b58f-abf873328b49.png)

</details>

_________

`#?#.aside-image-with-link:has([href^="https://www.whatsnxt.io/"])`

<details>
<summary>View image</summary>

![image](https://user-images.githubusercontent.com/84513173/185664759-86bd7be2-8abf-45d4-b166-bbf1028f5caf.png)

</details>