### PR TITLE
Enable syntax highlighting for AdBlock filter files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Attribute definitions
+[attr]adb   linguist-detectable linguist-language=AdBlock
+[attr]json -linguist-detectable linguist-language=JSONC
+
+# AdBlock filter files
+*.txt adb
+*.notlist adb
+AdawayHosts adb
+AnnoyancesList adb
+AntiCelebBirthList adb
+Adblocking?Open?Filter?JP adb
+Adblock?Plus*test?for?AdBlock adb
+Czech?Filters?for?Adblock?Plus adb
+Staying?On?The?Phone?Browser adb
+
+# JSON-ish data
+*.lsrules json
+/ClearURLs*/hash.txt json
+/Wiki/Dandelion?Sprout*DNS*.txt json


### PR DESCRIPTION
Support for AdBlock filter lists was [recently added](https://github.com/github/linguist/pull/5968) to GitHub Linguist. However, only `.txt` files beginning with an obvious-looking header are classified as filter-lists, which rules out most/all of the filter-lists in this repository.

This PR [adds an override](https://github.com/github/linguist/blob/master/docs/overrides.md) to declare the language of this project's `.txt` files explicitly.