### PR TITLE
Fix for Dailymotion autoplay

### DIFF
--- a/StopAutoplayOnYouTube.txt
+++ b/StopAutoplayOnYouTube.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 3.4]
 ! Title: 🎬 Stop Autoplay On Video Sites
 ! Expires: 7 days
-! Version: 03July2022v1
+! Version: 15September2022v1
 ! Description: Are you tired of having to turn off autoplay on YouTube, Vimeo, and other video sites every time you e.g. go to incognito mode? Do you work in classrooms/courserooms and don't want to accidentally show unfitting videos to your students/coursetakers? Are you worried of having to use specific extensions just for that purpose? Then this list is for you.
 ! Special thanks to https://github.com/llacb47 for waterproofing large parts of this list.
 ! Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#-english
@@ -17,6 +17,13 @@ youtube.com##.watch-sidebar-head
 m.youtube.com##.ytm-autonav-bar
 !#if !ext_ublock
 /endscreen.js$app=com.google.android.youtube|com.google.android.apps.youtube.vr|com.google.android.youtube.tv|com.google.android.youtube.googletv
+!#endif
+
+! ——— Dailymotion ———
+
+!#if ext_ublock
+! Likely only works on ublock
+||dailymotion.com/embed$redirect=click2load.html
 !#endif
 
 ! ——— Vimeo ———


### PR DESCRIPTION
> NOTE: This is likely a dirty fix, but from my small amount of research this is the best uBlock can achieve.

The embed URL is hardcoded [[...]`&autoplay-mute=true`[...]](https://www.dailymotion.com/embed?api=postMessage&apimode=json&app=com.dailymotion.neon&autoplay-mute=true&client_type=website&collections-action=trigger_event&collections-enable=fullscreen_only&endscreen-enable=false&info=false&like-action=trigger_event&like-enable=fullscreen_only&queue-enable=false&sharing-action=trigger_event&sharing-enable=fullscreen_only&ui-logo=false&watchlater-action=trigger_event&watchlater-enable=fullscreen_only&dmTs=499519) to enforce autoplay (most things are done from server-side), and loaded extremely early.  
To cleanly and completely bypass the autoplay would require an extension with HTML tag rewrite capability, uBlock can only remove HTML tags (and possibly not even early enough if there were rewrite capability), but not modify them (even with its support js hooks).

Force-bypass the autoplay-encoded embed by using [click2load.html][1] from uBlock

[1]: https://github.com/gorhill/uBlock/wiki/Resources-Library#empty-redirect-resources

Signed-off-by: Nicolas signed-log FORMICHELLA <stigpro@outlook.fr>