### PR TITLE
Add Amedia tracker pixel to norwegian list

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1,6 +1,6 @@
 ! Title: 🏔️ Dandelion Sprouts nordiske filtre for ryddigere nettsider
 ! Translated title: Dandelion Sprout's Nordic filters for tidier websites
-! Version: 25November2022v1
+! Version: 26November2022v1
 ! Expires: 1 day
 ! Lisens / Licence: https://github.com/DandelionSprout/adfilt/blob/master/LICENSE.md
 ! Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md
@@ -1626,6 +1626,7 @@ baadmagasinet.dk##.article-bottom .qx-inner > .qx-section:last-of-type
 ||erotikmix.dk/mixads300.html^
 */gifs/*emty.gif^$domain=yrkesbil.no|bilnorge.no
 -l%C3%BDsing-$image,domain=news.fo
+||s.api.no/mittari/c/article/*/sectionId/*.gif
 ! — — — — —
 ! 🇳🇴: Oppføringer for minst 3 nettsteder
 ! 🇬🇧: Entries for at least 3 websites


### PR DESCRIPTION
Amedia loads an invisible tracker gif on every page, this commit adds a block for it. The gif is injected along with other trackers (that is already blocked today).

Source code for the tracker gif:
```js
g().then(e=>{
  let {
    env: t
  }
  = e,
  {
    data: n
  }
  = e,
  i = n.sectionData && n.sectionData.isFrontPage;
  if (!t.params.token) {
    if (!i && t.publication.wwwDomain.indexOf('nettavisen.no') === - 1) {
      let o = document.createElement('img');
      o.setAttribute('style', 'display: none'),
      o.src = `//s.api.no/mittari/c/article/${ t.publication.wwwDomain }/sectionId/${ t.contentId }.gif?ts=${ Date.now() }`,
      document.body.appendChild(o)
    }
    if (t.gaia['linkpulse.enable']) {
      let o = document.createElement('script');
      t.publication.wwwDomain.indexOf('nettavisen.no') !== - 1 ? o.src = '//pp.lp4.io/app/50/48/67/50486792d9d93ec413000000.js' : o.src = '//pp.lp4.io/app/54/4e/1e/544e1e69e45a1d0757aa4802.js',
      document.body.appendChild(o)
    }
    if (window.location.pathname.match(/\/(?=sportspill)\/?(?!.*\btrav\b).*/)) {
      window.utag_data = {
        CampaignID: ''
      };
      let o = document.createElement('script');
      o.src = '//tags.tiqcdn.com/utag/norsktipping/affiliate/prod/utag.js',
      document.body.appendChild(o)
    }
  }
}); 
```