### PR TITLE
URLShortener breaks search on justice.gov

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1387,7 +1387,8 @@ $removeparam=/^_sgm_/i
 $removeparam=omnisendContactID
 
 ! https://ddos-guard.net/?affiliate=119953
-$removeparam=affiliate
+! https://github.com/DandelionSprout/adfilt/pull/720
+$removeparam=affiliate,domain=~justice.gov
 
 ! https://www.sears.com/?trco_id=5411901
 $removeparam=trco_id

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 26December2022v2
+! Version: 27December2022v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163


### PR DESCRIPTION
Search on justice.gov needs `affiliate` param to select where you are searching, without it it redirects to justice.gov
Test by searching anything in the top right search bar with `➗ Actually Legitimate URL Shortener Tool` list enabled



<details>
  <summary>Irrelevant info</summary>

valid values for affiliate appears to be: `justice`, `justice-archive` and `test`
</details>