### PR TITLE
Fix issue with removing 'data1' on urls for cmvm.pt as reported on my last comment on the "Legitimate URL Shortener" General discussion

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -905,7 +905,7 @@ $removeparam=afftrack
 $removeparam=atid
 $removeparam=/^clickref[0-9]?=/
 $removeparam=cuid
-$removeparam=data1
+$removeparam=data1,domain=~web3.cmvm.pt
 $removeparam=data2
 $removeparam=data3
 $removeparam=effi_id


### PR DESCRIPTION
https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-4594226