### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 05January2023v1
+! Version: 05January2023v2
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163

--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1455,6 +1455,10 @@ $removeparam=qq-pf-to
 ! https://www.cbr.com/star-wars-marvel-should-abandon-canon/?mibextid=Zxz2cZ#Echobox=1672754520
 $removeparam=mibextid
 
+! https://www.telegraph.co.uk/business/2022/01/27/wasps-bees-force-heathrow-take-offs-abandoned/?li_source=LI&li_medium=liftigniter-onward-journey
+$removeparam=li_source
+$removeparam=li_medium
+
 ! ——— General blocking rules ——— !
 !! Scripts that solely exist to make URLs longer.
 ! https://github.com/DandelionSprout/adfilt/pull/320


### PR DESCRIPTION
Remove `li_source` and `li_medium`:
* `https://www.telegraph.co.uk/business/2022/01/27/wasps-bees-force-heathrow-take-offs-abandoned/?li_source=LI&li_medium=liftigniter-onward-journey`

You can find those for example in the "More stories" section next to the article.

tracking from: `https://www.liftigniter.com/`