### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 16April2023v2
+! Version: 17April2023v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1817,6 +1817,8 @@ $removeparam=tbas
 ! https://www.google.no/search?newwindow=1&source=univ&tbm=isch&q=fursuit&hl=no&fir=nwjEObe4q69GJM%2(…abridged by Dandelion…)3ezNNzM%252C_&usg=AI4_-kQL51ABubPt5Njl2wYsc9VKumls8Q&sa=X (23/01/2021)
 !+ NOT_OPTIMIZED
 $removeparam=fir
+||google.*/books$removeparam=source
+||google.*/flights$removeparam=source
 ||google.*/search$removeparam=source
 ! https://www.google.no/search?q=beetle&sa=X&hl=no&tbm=isch&ictx=1&fir=hA_sSJDgDUD05M%252Cra9C8zPHQZacDM%252C_%253BjHMPo_nzeT4CHM%252CJ-BwVgjGhTXbRM%252C_%253B8idWw3wKyv8TEM%252CEq9NAOyMjA8-LM%252C_%253BIr3d2npsvZA5mM%252Carwh6OytVDPyyM%252C_&vet=1&usg=AI4_-kQywyXRkRPeAWvGNhHd9wKvex-4AQ#imgrc=hA_sSJDgDUD05M (03/05/2021)
 @@||google.*&tbm=isch&*#imgrc=$removeparam=fir


### PR DESCRIPTION
I didn't notice any problems if `source` is removed from these paths:

`https://www.google.com/flights?q=new+york&source=lnms`
`https://play.google.com/books?source=gbs_lp_bookshelf_list`
`https://books.google.fi/books?source=gbs_lp_bookshelf_list`
