### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 23April2023v3
+! Version: 25April2023v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1473,6 +1473,11 @@ $removeparam=/^adppopup=[a-eg-zA-EG-Z0-9]/
 $removeparam=relatedposts_hit
 $removeparam=relatedposts_origin
 $removeparam=relatedposts_position
+
+! https://itsfoss.com/linux-gaming-guide/?ref=news.itsfoss.com
+! https://www.raspberrypi.org/documentation/usage/kodi/?ref=itsfoss.com
+$removeparam=/^ref=itsfoss.com$/
+$removeparam=/^ref=news.itsfoss.com$/
 
 ! ——— General blocking rules ——— !
 !! Scripts that solely exist to make URLs longer.


### PR DESCRIPTION
`itsfoss.com` adds `ref` param to almost all links on their site.

Examples:
```url
https://proton.me/pass?ref=news.itsfoss.com
https://getsol.us/branding/?ref=news.itsfoss.com
https://itsfoss.com/protect-email-address/?ref=news.itsfoss.com
https://simplelogin.io/?ref=itsfoss.com
https://itsfoss.com/long-term-support-lts/?ref=news.itsfoss.com
https://itsfoss.com/linux-gaming-guide/?ref=news.itsfoss.com
https://www.raspberrypi.org/documentation/usage/kodi/?ref=itsfoss.com
```