### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 25April2023v1
+! Version: 27April2023v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -3970,6 +3970,9 @@ $removeparam=ad_sub,domain=homo.xxx
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-5691902
 ||kongregate.com^$document,removeparam=acomplete
+
+! https://www.bloomberg.com/news/articles/2023-04-18/netflix-to-exit-the-dvd-delivery-business-after-25-years?re_source=boa_related
+||bloomberg.com^$removeparam=re_source
 
 !#if !env_mobile
 ! ——— Entries mostly dedicated to maximising image sizes (thus poorly suited for phones) ———


### PR DESCRIPTION
Remove `re_source` :

* `https://www.bloomberg.com/news/articles/2023-04-18/netflix-to-exit-the-dvd-delivery-business-after-25-years?re_source=boa_related`

Can be found in the links on  `More from Bloomberg` and `Top Reads` sections below articles.