### PR TITLE
Fix missing escaped character

### DIFF
--- a/Dandelion Sprout-s Redirector Assistant List/DandelionSproutRedirectorList.json
+++ b/Dandelion Sprout-s Redirector Assistant List/DandelionSproutRedirectorList.json
@@ -268,7 +268,7 @@
             "exampleUrl": "https://static.tvno.nu/4084728?forceFit=0&height=760&quality=50&width=1350",
             "exampleResult": "https://static.tvno.nu/4084728?forceFit=0&height=760&quality=100&width=1350",
             "error": null,
-            "includePattern": "(.*)&quality=[2-8]\d(&(.*))?$",
+            "includePattern": "(.*)&quality=[2-8]\\d(&(.*))?$",
             "excludePattern": "",
             "patternDesc": "JPG qualities below 20 are likely done for comedic purposes only, and 90-99 are acceptable tradeoffs for smaller image byte sizes.",
             "redirectUrl": "$1&quality=100$2",


### PR DESCRIPTION
Redirector fails to import it because of the mis-escaped `\d`