### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 16May2023v1
+! Version: 21May2023v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -1874,6 +1874,12 @@ $removeparam=ogbl
 ||support.google.com^$removeparam=ref_topic
 ! https://egon-no.translate.goog/ledige-stillinger/204bd5b2-6f9b-45bf-893d-1c0b21f9dc8a?_x_tr_sl=no&_x_tr_tl=en&_x_tr_hl=no&_x_tr_pto=wapp
 $removeparam=_x_tr_pto
+! https://www.google.com/webhp?sa=X
+||google.*/finance$document,removeparam=sa
+||google.*/flights$document,removeparam=sa
+||google.*/maps$document,removeparam=sa
+||google.*/search$document,removeparam=sa
+||google.*/webhp$document,removeparam=sa
 
 !!! ———TikTok———
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-632259


### PR DESCRIPTION
Remove `sa` parameter.  Adguard's list already removes it from `/search` path, but I added more paths that I think should be ok, and also limited it to just the document to play it safe.

Example urls:
* `https://www.google.com/flights?q=test&hl=fi&source=lnms&tbm=flm&sa=X`
* `https://www.google.com/finance?sa=X`
* `https://www.google.com/search?q=test&source=lnms&sa=X`
* `https://maps.google.com/maps?q=new+york&source=lmns&entry=mt&hl=en&sa=X`
* `https://www.google.com/webhp?sa=X`

Something like `||google.$document,removeparam=/^sa=X$/` could also work, but I don't have time to test everywhere, the only problem I know with removing this parameter is that if you remove it from `/url?` path but that path also has issues if you remove other params like `ved`.

_____

Maybe old documentation, but might give some idea of what it is for:

`https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#sa`