### PR TITLE
Update LegitimateURLShortener.txt

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -1,5 +1,5 @@
 ! Title: ➗ Actually Legitimate URL Shortener Tool
-! Version: 1June2023v2
+! Version: 2June2023v1
 ! Expires: 1 day
 ! Description: In a world dominated by bit.ly, adf.ly, and several thousand other malware cover-up tools, this list reduces the length of URLs in a much more legitimate and transparent manner. Essentially, it automatically removes unnecessary $/& values from the URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Enjoy.
 ! Homepage: https://github.com/DandelionSprout/adfilt/discussions/163
@@ -4021,6 +4021,9 @@ $document,removeparam=wp_source,domain=ac24.cz|ambcrypto.com|glispa.com|whitepag
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-6063968
 ||as.com^$removeparam=ssm,document
+
+! https://www.thisismoney.co.uk/money/mortgageshome/article-12148391/Mortgage-approvals-house-purchases-fall-April.html?molReferrerUrl=https%3A%2F%2Fwww.dailymail.co.uk%2Fmoney%2Findex.html
+||thisismoney.co.uk^$removeparam=molReferrerUrl
 
 !#if !env_mobile
 ! ——— Entries mostly dedicated to maximising image sizes (thus poorly suited for phones) ———


### PR DESCRIPTION
From here links here `https://www.dailymail.co.uk/money/index.html`

Remove `molReferrerUrl` :
* `https://www.thisismoney.co.uk/money/mortgageshome/article-12148391/Mortgage-approvals-house-purchases-fall-April.html?molReferrerUrl=https%3A%2F%2Fwww.dailymail.co.uk%2Fmoney%2Findex.html`
