### PR TITLE
cfd TLD - Exclude freedium.cfd

### DIFF
--- a/Alternate versions Anti-Malware List/AntiMalwareAdGuardHome.txt
+++ b/Alternate versions Anti-Malware List/AntiMalwareAdGuardHome.txt
@@ -95,6 +95,8 @@
 ! https://github.com/AdguardTeam/AdguardFilters/issues/137635
 ||*.cfd^
 @@||frcoal.cfd^
+! https://github.com/hagezi/dns-blocklists/issues/1742
+@@||freedium.cfd^
 ! Experimental attempt to cover a few hardcore spam ASNs
 
 


### PR DESCRIPTION
See: https://github.com/hagezi/dns-blocklists/issues/1742