### PR TITLE
De-hardcode "AntiFaviconList" filter

### DIFF
--- a/Special security lists/AntiFaviconList.txt
+++ b/Special security lists/AntiFaviconList.txt
@@ -3,4 +3,4 @@
 ! Version: 23January2021v1-Beta
 ! Description: The article at https://www.ghacks.net/2021/01/22/favicons-may-be-used-to-track-users/ probably explains this list better than anything I could've written myself.
 ! Homepage: https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#-english
-/favicon.ico|
+*##^link[rel~='icon']


### PR DESCRIPTION
Currently, the list specifically blocks `favicon.ico`, which isn't the favicon filename for many sites. I've updated it to use an HTML filter (in case a browser (if any) catches the favicon before the filter removes it) that removes all link tags which have `icon` as an item in the rel attribute.

It needs to be checked with `~=` instead of `=` because `rel` is an "unordered set of unique space-separated keywords" (from MDN), and in many cases `rel` has more than one item, e.g. `alternate icon`