### PR TITLE
Add filters for Version2.dk inline ads

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -1554,6 +1554,9 @@ vartoslo.no##.vo-annonse
 vb.is##.big_spons
 veitingastadir.is##.footer_top > .footer-wrap > .columns
 version2.dk###headersub
+version2.dk##.disclosure-text:upward(.block-tm-kevel)
+version2.dk##.disclosure-text:upward(.jobs-wrapper)
+version2.dk##.node__label--sponsored_content:upward(.in-content-article)
 vg.no##.finn-placeholder
 vg.no##div[id^=ad-front-netboard_]
 vg.no#?#.bundle li[class^=css-]:has(div[data-ad-subtype])


### PR DESCRIPTION
This PR adds filters for inline ads on version2.dk

Before:

![image](https://github.com/DandelionSprout/adfilt/assets/626791/dc236024-f104-44a2-a69e-acf45abc6dd7)

After:

![image](https://github.com/DandelionSprout/adfilt/assets/626791/5e5649cc-5807-4ba1-a614-138776dca845)
