### PR TITLE
Adding exclusion for madeofmore.agency

### DIFF
--- a/Alternate versions Anti-Malware List/AntiMalwareAdGuardHome.txt
+++ b/Alternate versions Anti-Malware List/AntiMalwareAdGuardHome.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.13]
 ! Title: 💊 Dandelion Sprout's Anti-Malware List (for AdGuard Home, AdGuard for Android/Windows' DNS filtering, and Pi-Hole FTL ≥5.22)
-! Version: 19December2023v2
+! Version: 24December2023v1
 ! Expires: 2 days
 ! Description: This list goes the extra kilometer to prevent more malware than other mainstream anti-malware lists. It blocks heavily abused top-level domains (and even search engine results for them), blocks domains used in malware redirection trains and in domain parking schemes, blocks sponsored Windows PUP nags on PC guide articles, uses mass blocking of domains belonging to bad IPs, and has many other subcategories that give it a solid advantage over similar lists out there.
 ! For other security-specific lists I've made, check out https://github.com/DandelionSprout/adfilt/tree/master/Special%20security%20lists
@@ -23,7 +23,7 @@
 ||*.top^$denyallow=caitlin.top|corriente.top|gdtot.top|nicenature.top|reminder.top|magocoro.top|castlevania.top|suiten.top|shucks.top|1stream.top|ambr.top|techblog.top|changlam10.top|changlam11.top|pdcdn1.top|mastodon.top|pressplay.top|chillx.top|strims.top|thedesk.top|audioforyou.top
 ! International topical domains that have consistently horrendous scores on watchlists of bad TLDs, and whose use for legit purposes is practically non-existent.
 ||*.loan^
-||*.agency^$denyallow=battlefield.agency|baam.agency|robotzebra.agency|uphotel.agency|ws.agency
+||*.agency^$denyallow=battlefield.agency|baam.agency|robotzebra.agency|uphotel.agency|ws.agency|madeofmore.agency
 ||*.gdn^$denyallow=cst.gdn|pss.gdn
 ||*.bid^
 ||*.ooo^$denyallow=toast.ooo


### PR DESCRIPTION
The '.agency' block is preventing legitimate DNS resolution for 'madeofmore.agency' which is the website of a Design agency based in the UK.