### PR TITLE
Removed duplicate

### DIFF
--- a/GameConsoleAdblockList.txt
+++ b/GameConsoleAdblockList.txt
@@ -66,7 +66,6 @@
 ! ——— Xbox Series X/S ———
 ! I received a tip by E-mail of somehow who said he had accomplished this, mostly as a result of using other lists, most prominently AdGuard DNS Filter and HaGeZi's Pro++ Blocklist.
 ||at.atwola.com^
-||watson.events.data.microsoft.com^
 ||nw-umwatson.events.data.microsoft.com^
 ! Just in case:
 *watson.events.data.microsoft.com^


### PR DESCRIPTION
*watson.events.data.microsoft.com^ will cover any symbols/subdomains; therefore, ||watson.events.data.microsoft.com^ is not necessary.