### PR TITLE
Update the filter for Discord's CDN

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -3999,7 +3999,7 @@ $removeparam=post_index,domain=reddit.com|reddittorjg6rue252oqsxryoxengawnmo46qy
 $removeparam=auto_token,domain=nextdoor.com
 $removeparam=mobile_deeplink_data
 $removeparam=link_source_user_id,domain=nextdoor.com
-$removeparam=is,domain=nextdoor.com|discordapp.*
+$removeparam=is,domain=nextdoor.com
 $removeparam=mar,domain=nextdoor.com
 
 ! https://www.cbs42.com/alabama-news/fedex-driver-identified-questioned-in-case-of-300-400-packages-found-in-alabama-woods/?ipid=wiat_recirc_1%20?ipid=promo-link-block1
@@ -4330,10 +4330,6 @@ $removeparam=dyn,domain=clink2.com|dlink2.com,doc
 
 ! https://generated.photos/human-generator/?ref=easywithai
 *ref=easywithai*$doc,removeparam=/^ref=easywithai$/
-
-! https://media.discordapp.net/attachments/941646290092175393/1158063669595340830/IMG_2447.jpg?ex=651ae256&is=651990d6&hm=a2c8bf17ad5eaf4e25ed48b7b4beccb5295795fe5b237f514db154c2f1521070& (01/10/2023)
-||discordapp.$removeparam=ex
-||discordapp.$removeparam=hm
 
 ! masterkia: https://slack.com/downloads/linux?t=[Slack channel ID]
 ||slack.com/downloads/$doc,removeparam=t


### PR DESCRIPTION
Files don't work anymore without `is`, `ex` and `hm` parameters.