### PR TITLE
Remove Nintendo 3DS and Wii U entries from game console adblock list

### DIFF
--- a/GameConsoleAdblockList.txt
+++ b/GameConsoleAdblockList.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.6]
 ! Title: 🎮 Game Console Adblock List
-! Version: 27December2023v1-Alpha
+! Version: 27April2024v1-Alpha
 ! Expires: 10 days
 ! Description: Much like there's now lists for AdGuard Home and Pi-hole to block ads on smart-TVs, here's an attempt from me at doing the same for videogame consoles with AdGuard Home. Enjoy.
 ! Important note: To block ads in the consoles' dedicated internet browsers with AdGuard Home, and not in the system menus, check out https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AdGuard%20Home%20Compilation%20List/AdGuardHomeCompilationList.txt instead.
@@ -16,18 +16,6 @@
 ||nsx.np.dl.playstation.net^
 ! Ticker ads in the XMB clockbar
 ||adproxy.ndmdhs.com^
-
-! ——— Nintendo 3DS ———
-! Blocks the "Theme Shop", with the intention of preventing the annoying pink "New themes have arrived" dot in the upper left of the Home Menu from reappearing all the time, until a point in 2023 when new themes stopped arriving anyway.
-! The entry is known to block Animal Crossing Home Designer's "Special design requests" system, although that system has been inactive since 2017.
-! WARNING: The "Theme Shop" should be visited once to remove the pink dot, and only then should this list be subscribed to.
-||npdl.cdn.nintendowifi.net^
-
-! ——— Wii U ———
-! Believed to reduce the initial loading time of Wii Sports Club by several seconds
-! While the same domain is used by Animal Crossing Plaza, it does not seem to have any impact if it's blocked or not blocked.
-! Since no third-party Miiverse clients with console support are believed to be able to exist by now (January 2020), this entry is pretty much here to stay.
-||discovery.olv.nintendo.net^
 
 ! ——— Xbox One ———
 ! Removes sponsored info slots in the system menu


### PR DESCRIPTION
Online services for 3DS and Wii U have ceased to exist as of a few weeks ago, so there's pretty much no point in having these anymore.