### PR TITLE
Fix LegitimateURLShortener on ublock origin

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -307,9 +307,6 @@ $removeparam=CMP
 
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-750434
 $doc,removeparam=/^OCID=.*$/i,domain=~youtube.com|~reiseauskunft.bahn.de|~msn.com
-!#if adguard
-@@$removeparam=/^OCID=.*$/i,app=Microsoft.Msn.News.exe
-!#endif
 $removeparam=tduid,domain=~tradedoubler.com
 $removeparam=irclickid
 $removeparam=irclicid


### PR DESCRIPTION
those lines break the whole filter on ublock origin : 
`!#if adguard
@@$removeparam=/^OCID=.*$/i,app=Microsoft.Msn.News.exe
!#endif`
the error causes the filter to basically not work at all.

Without the fix : 
![image](https://github.com/user-attachments/assets/89286bf9-3bbb-4e13-b59a-dfc12f4a0b9a)
With the fix : 
![image](https://github.com/user-attachments/assets/ecba1706-7d4b-4d26-9c5d-c92c65bbcddd)
