### PR TITLE
Block bromite.org

### DIFF
--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -102,6 +102,7 @@ www.google.*##a[oncontextmenu][href^="https://books.google."]:upward(2)
 ||ssl.bblck.me^$doc
 ||allblock.net^$doc
 ||microsoftedge.microsoft.com/addons/detail/allblock/nkllnmjaaifdphkfbmedklkimjmnjeen^$doc
+||bromite.org^$doc
 ! Malicious or purchaseable domains found in videogame manuals, title screens, or game driver/patch sites
 ||acclaimsports.com^$doc
 ||acclaimmaxsports.com^$doc


### PR DESCRIPTION
Former widely used privacy & security hardened Chromium browser for Android, used for ex. downloads & updates, and also provided a filterlist used by other Android Chromium-based browsers.

Developer went AWOL in December 2022, and the domain is set to expire on October 10th, meaning it'll be snatched up and possibly abused.

More info: https://infosec.exchange/@divested/113226945978043050