### PR TITLE
Update NordicFiltersABP-Inclusion.txt

### DIFF
--- a/NorwegianExperimentalList alternate versions/NordicFiltersABP-Inclusion.txt
+++ b/NorwegianExperimentalList alternate versions/NordicFiltersABP-Inclusion.txt
@@ -4109,9 +4109,9 @@ affarsstaden.se#?#main > .elementor > section.elementor-section:last-child:has(a
 affarsvarlden.se##article.article-list-item:has(a[href*="/native/"])
 affarsvarlden.se##.Modal, .article-list-item--native, .advert-notice-box, .native-popup, .takeover-wrap, .native-notice-box, .darwin--content
 aftonbladet.se##article[class^=article-wrapper] ~ div[class^=hyperion]:has(a[href*="/t?a="], a[href*="/click"], a[href^=http][nofollow], a[href^=http][rel*=nofollow], iframe[src*=pricerunner], iframe[src*="/ads/"])
-aftonbladet.se##aside > div[class^=hyperion]:has(a[href*="/rabattkod"], a[href*="/kampanj"], a[href*="/brandstudio"], a[href*="/brand-studio"])
+aftonbladet.se##aside > div[class^=hyperion]:has(a[href*="/rabattkod"], a[href*="/brandstudio"], a[href*="/brand-studio"])
 aftonbladet.se#?#section[class*=layout-main] > div[class^=hyperion-css]:has(a[href*="/produkt/"]:not(a[href^="/"]), a[href*="/varumarken/"]:not(a[href^="/"]), a[href*="/prisjakt.nu"])
-aftonbladet.se###superright-side, a[href*="/casinoguide"], [id^=adPlacement], a[href^="https://kampanj."], a[href*="/rabattkod"][data-test-tag=internal-link], a[href^="/sportbladet/speltips/"], a[href*="aftonbladet.se/kampanj/"], #takeover-container, div[class^=stickylogin]
+aftonbladet.se###superright-side, a[href*="/casinoguide"], [id^=adPlacement], a[href*="/rabattkod"][data-test-tag=internal-link], #takeover-container, div[class^=stickylogin]
 aftonbladet.se#?#:is(main > section a[data-test-tag=internal-link], #main > section a[data-test-tag=internal-link], main > section a[href*="godare.se"], #main > section a[href*="godare.se"], main > aside a[data-test-tag=internal-link]):has-text(innehåller annonslänkar)
 aftonbladet.se#?#:is(main > section > div[class^=hyperion], #main > section > div[class^=hyperion]):has(a[href*="/brandstudio"], a[href*="/brand-studio"], a[href*="/rabattkod/"], a[href*="/casinoguide/"], iframe[src*=compricer])
 aftonbladet.se,godare.se#?#div[style*="min-height:240px"]:has(iframe[src*="/widgets/ads/"])


### PR DESCRIPTION
Those pages are the purchase pages for Aftonbladet. So if you want to purchase a subscription OR cancel one, you have to go through those pages so they should not be filtered away. I can amongst others hide the cancellation button.