### PR TITLE
fix: remove outdated e24.no rule hiding non ad related content

### DIFF
--- a/NorwegianList.txt
+++ b/NorwegianList.txt
@@ -397,7 +397,6 @@ telefonterror.co.no,ukendtnummer.dk##.ad-comments
 tiendeo.no###header-standard-container
 indblik.net##div[id^=adni_widgets-]
 bt.no###related-articles + div[class^=_]
-e24.no,e24-no.translate.goog###main > div:nth-of-type(1)
 itavisen.no##.td-header-ad-wrap
 purehelp.no##.dfptop
 eikernytt.no###nav_menu-3.widget_nav_menu


### PR DESCRIPTION
I'm pretty sure this removed rule is only hiding the entire content area on e24.no sub collection pages. It's not related to any ads. Other rules are hiding ads on the frontpage where no element with id #main exists, same goes for article pages.

I'm not 100% sure this is the only place to remove this though. 

Example pages which this rule affect:
https://e24.no/forfatter/vilde-elgaaen
https://e24.no/norsk-oekonomi
https://e24.no/emne/ola-borten-moe
https://e24.no/hendelse/anders-kaitlin

<img width="2830" height="1142" alt="image" src="https://github.com/user-attachments/assets/5fdf2a33-f9fe-4ab6-a4a8-44812cd0f4ec" />


More context, details and images here: 
https://github.com/DandelionSprout/adfilt/issues/1206



