### PR TITLE
Add removeparam rules for zhihu.com

### DIFF
--- a/LegitimateURLShortener.txt
+++ b/LegitimateURLShortener.txt
@@ -3630,6 +3630,9 @@ $removeparam=brand,domain=cyberghostvpn.com|privateinternetaccess.com
 ||zhihu.com^$removeparam=hybrid_search_source
 ||zhihu.com^$removeparam=hybrid_search_extra
 
+! https://github.com/DandelionSprout/adfilt/pull/1216
+||zhihu.com^$removeparam=share_code
+
 ! https://www•theregister•com/2021/12/20/linux_5_16_rc6/?td=keepreading-btm
 ||theregister.com^$removeparam=td
 


### PR DESCRIPTION
An example link: `https://www.zhihu.com/question/1986182321871812189?share_code=70GqcTDwvRAD`

This tracking parameters automatically added by the software after sharing a link on the Zhihu app.