### PR TITLE
Patch 1

### DIFF
--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -20,6 +20,9 @@
 @@||wceui.top^
 ! https://github.com/DandelionSprout/adfilt/issues/1242
 @@://maven.*.top^$doc
+@@||qpmegathread.top^
+! Public index/guide site with original content. No ads, no redirects, no malware. Actively maintained and used by a community.
+
 ! International topical domains that have consistently horrendous scores on watchlists of bad TLDs, and whose use for legit purposes is practically non-existent.
 ||loan^$doc
 ||bid^$doc

--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -20,8 +20,9 @@
 @@||wceui.top^
 ! https://github.com/DandelionSprout/adfilt/issues/1242
 @@://maven.*.top^$doc
-@@||qpmegathread.top^
 ! Public index/guide site with original content. No ads, no redirects, no malware. Actively maintained and used by a community.
+@@||qpmegathread.top^
+
 
 ! International topical domains that have consistently horrendous scores on watchlists of bad TLDs, and whose use for legit purposes is practically non-existent.
 ||loan^$doc


### PR DESCRIPTION
Adding qpmegathread.top , we use it as a community based megathread. Some users use your malware list and want to continue using it but still want to use our site. Figured the least i could do is ask.