### PR TITLE
Remove CloudFlare-owned IP causing false positives on AGH

### DIFF
--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1542,9 +1542,7 @@ $all,ipaddress=198.23.255.14
 ||trumops.com^$doc
 ||runmodes.com^$all
 $all,ipaddress=91.121.67.60
-$all,ipaddress=172.67.186.189
 ||91.121.67.60^$all
-||172.67.186.189^$all
 ! https://scammer•info/t/mcafee-phish/83725
 ||securefirst.us-east-1.linodeobjects.com^$all
 ! https://www•virustotal•com/gui/file/4293c1d8574dc87c58360d6bac3daa182f64f7785c9d41da5e0741d2b1817fc7/community

--- a/Dandelion Sprout's Anti-Malware List.txt
+++ b/Dandelion Sprout's Anti-Malware List.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.13]
 ! Title: 💊 Dandelion Sprout's Anti-Malware List
-! Version: 21May2026v1
+! Version: 23May2026v1
 ! Expires: 1 day
 ! Description: This list goes the extra kilometer to prevent more malware than other mainstream anti-malware lists. It blocks domains and domain patterns used in malware redirection trains and in domain parking schemes, blocks sponsored Windows PUP nags on PC guide articles, uses mass blocking of domains belonging to bad IPs, and has many other subcategories that give it a solid advantage over similar lists out there.
 ! Note: When asking us to whitelist a site: Make sure the site has some sort of public content. Non-public sites and alias sites are usually not whitelisted.


### PR DESCRIPTION
The IP `172.67.186.189` is an IP owned by Cloudflare. These rules causes false positives for legitimate domains behind Cloudflare.

https://www.abuseipdb.com/check/172.67.186.189

*Also: `working-tree-encoding=UTF-8-BOM` in `.gitattributes` causes non-BOM files like `Dandelion Sprout's Anti-Malware List.txt` to error out git operations on some machines. You should migrate away from using BOM unless it's explicitly needed for some reason.*